### PR TITLE
feat: remove title field from EvaluationComment model

### DIFF
--- a/docs/development/agents.md
+++ b/docs/development/agents.md
@@ -192,6 +192,12 @@ Before deploying a new agent:
 - Check that text ranges are valid
 - Review sample documents for highlighting examples
 
+**Comment structure note:**
+- Comments no longer have separate title fields
+- Each comment's description should begin with a clear, concise statement
+- This opening statement serves as a summary (like a title would)
+- Follow with detailed explanation in the rest of the description
+
 **Grades are inconsistent:**
 - Refine grading rubric with specific criteria
 - Add examples of different grade levels

--- a/prisma/migrations/20250701223000_remove_comment_title/migration.sql
+++ b/prisma/migrations/20250701223000_remove_comment_title/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `title` on the `EvaluationComment` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "EvaluationComment" DROP COLUMN "title";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,7 +136,6 @@ model EvaluationVersion {
 
 model EvaluationComment {
   id                  String              @id @default(uuid())
-  title               String
   description         String
   importance          Int?
   grade               Int?

--- a/src/app/api/agents/[agentId]/export-data/route.ts
+++ b/src/app/api/agents/[agentId]/export-data/route.ts
@@ -5,6 +5,7 @@ import { authenticateRequest } from "@/lib/auth-helpers";
 import { prisma } from "@/lib/prisma";
 import { errorResponse, successResponse, commonErrors } from "@/lib/api-response-helpers";
 import type { AgentExportData, EvaluationWhereConditions } from "@/types/api/agent-export";
+import { extractTitleFromDescription } from "@/utils/ui/extractTitle";
 
 export async function GET(request: NextRequest, context: { params: Promise<{ agentId: string }> }) {
   const params = await context.params;
@@ -184,7 +185,7 @@ export async function GET(request: NextRequest, context: { params: Promise<{ age
           self_critique: evalVersion.selfCritique,
           comment_count: evalVersion.comments.length,
           comments: evalVersion.comments.map((comment) => ({
-            title: comment.title,
+            title: extractTitleFromDescription(comment.description).title,
             description: comment.description,
             importance: comment.importance,
             grade: comment.grade,

--- a/src/app/api/monitor/evaluations/route.ts
+++ b/src/app/api/monitor/evaluations/route.ts
@@ -24,7 +24,9 @@ export async function GET(request: NextRequest) {
       orderBy: {
         createdAt: "desc",
       },
-      include: {
+      select: {
+        id: true,
+        createdAt: true,
         document: {
           select: {
             id: true,
@@ -58,7 +60,14 @@ export async function GET(request: NextRequest) {
             createdAt: "desc",
           },
           take: 1,
-          include: {
+          select: {
+            id: true,
+            version: true,
+            summary: true,
+            analysis: true,
+            grade: true,
+            selfCritique: true,
+            createdAt: true,
             agentVersion: {
               select: {
                 name: true,
@@ -68,7 +77,6 @@ export async function GET(request: NextRequest) {
             comments: {
               select: {
                 id: true,
-                title: true,
                 description: true,
                 importance: true,
                 grade: true,

--- a/src/app/docs/[docId]/evaluations/components/VersionDetails.tsx
+++ b/src/app/docs/[docId]/evaluations/components/VersionDetails.tsx
@@ -12,6 +12,7 @@ import {
   ListBulletIcon,
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
+import { extractTitleFromDescription } from "@/utils/ui/extractTitle";
 
 import { TaskLogs } from "./TaskLogs";
 
@@ -61,7 +62,7 @@ export function VersionDetails({
       selfCritique: selectedVersion.selfCritique,
       comments: selectedVersion.comments.map((comment, index) => ({
         id: `comment-${index}`,
-        title: comment.title,
+        title: extractTitleFromDescription(comment.description).title,
         description: comment.description,
         importance: comment.importance || null,
         grade: comment.grade || null,
@@ -215,14 +216,14 @@ export function VersionDetails({
                 className="rounded-lg border border-gray-200 bg-white p-4"
               >
                 <div className="mb-2 flex items-center justify-between">
-                  <h4 className="font-medium text-gray-900">{comment.title}</h4>
+                  <h4 className="font-medium text-gray-900">{extractTitleFromDescription(comment.description).title}</h4>
                 </div>
                 <div className="prose max-w-none">
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
                     rehypePlugins={[rehypeRaw]}
                   >
-                    {comment.description}
+                    {extractTitleFromDescription(comment.description).remainingDescription || comment.description}
                   </ReactMarkdown>
                 </div>
                 {comment.highlight && (

--- a/src/components/DocumentWithEvaluations.tsx
+++ b/src/components/DocumentWithEvaluations.tsx
@@ -33,6 +33,7 @@ import {
 import { HEADER_HEIGHT_PX } from "@/utils/ui/constants";
 import { formatWordCount } from "@/utils/ui/documentUtils";
 import { getDocumentFullContent } from "@/utils/documentContentHelpers";
+import { extractTitleFromDescription } from "@/utils/ui/extractTitle";
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
@@ -161,7 +162,7 @@ function CommentsSidebar({
                         className={`font-medium ${expandedTag === tag ? "text-blue-900" : "text-gray-900"}`}
                       >
                         <MarkdownRenderer className="inline">
-                          {comment.title}
+                          {extractTitleFromDescription(comment.description).title}
                         </MarkdownRenderer>
                       </h3>
                       <div className="flex shrink-0 items-center gap-2">
@@ -195,41 +196,44 @@ function CommentsSidebar({
                         />
                       </div>
                     </div>
-                    {comment.description && (
-                      <div
-                        className={`mt-1 ${
-                          expandedTag === tag
-                            ? "text-gray-800"
-                            : "line-clamp-1 text-gray-600"
-                        }`}
-                      >
-                        <MarkdownRenderer>
-                          {comment.description}
-                        </MarkdownRenderer>
-                        {expandedTag === tag && (
-                          <div className="mt-2 text-xs text-gray-400">
-                            {comment.grade !== undefined && (
-                              <span className="mr-4">
-                                Grade:{" "}
-                                <GradeBadge
-                                  grade={comment.grade}
-                                  variant="light"
-                                  size="xs"
-                                />
-                              </span>
-                            )}
-                            {comment.importance !== undefined && (
-                              <span>
-                                Importance:{" "}
-                                <span>
-                                  {getImportancePhrase(comment.importance)}
+                    {(() => {
+                      const { remainingDescription } = extractTitleFromDescription(comment.description);
+                      return remainingDescription ? (
+                        <div
+                          className={`mt-1 ${
+                            expandedTag === tag
+                              ? "text-gray-800"
+                              : "line-clamp-1 text-gray-600"
+                          }`}
+                        >
+                          <MarkdownRenderer>
+                            {remainingDescription}
+                          </MarkdownRenderer>
+                          {expandedTag === tag && (
+                            <div className="mt-2 text-xs text-gray-400">
+                              {comment.grade !== undefined && (
+                                <span className="mr-4">
+                                  Grade:{" "}
+                                  <GradeBadge
+                                    grade={comment.grade}
+                                    variant="light"
+                                    size="xs"
+                                  />
                                 </span>
-                              </span>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )}
+                              )}
+                              {comment.importance !== undefined && (
+                                <span>
+                                  Importance:{" "}
+                                  <span>
+                                    {getImportancePhrase(comment.importance)}
+                                  </span>
+                                </span>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      ) : null;
+                    })()}
                   </div>
                 </div>
               </div>

--- a/src/components/EvaluationDetails.tsx
+++ b/src/components/EvaluationDetails.tsx
@@ -11,12 +11,12 @@ import {
 
 import { GradeBadge } from "@/components/GradeBadge";
 import { TaskLogs } from "@/app/docs/[docId]/evaluations/components/TaskLogs";
+import { extractTitleFromDescription } from "@/utils/ui/extractTitle";
 
 export type EvaluationTab = "analysis" | "summary" | "comments" | "selfCritique" | "logs";
 
 interface Comment {
   id: string;
-  title: string;
   description: string;
   importance?: number | null;
   grade?: number | null;
@@ -150,7 +150,7 @@ export function EvaluationDetails({
                 >
                   <div className="mb-2 flex items-center justify-between">
                     <h4 className="font-medium text-gray-900">
-                      {comment.title}
+                      {extractTitleFromDescription(comment.description).title}
                     </h4>
                     <div className="flex items-center space-x-2">
                       {comment.grade && <GradeBadge grade={comment.grade} />}
@@ -166,7 +166,7 @@ export function EvaluationDetails({
                       remarkPlugins={[remarkGfm]}
                       rehypePlugins={[rehypeRaw]}
                     >
-                      {comment.description}
+                      {extractTitleFromDescription(comment.description).remainingDescription || comment.description}
                     </ReactMarkdown>
                   </div>
                 </div>

--- a/src/components/HighlightedMarkdown.tsx
+++ b/src/components/HighlightedMarkdown.tsx
@@ -16,6 +16,7 @@ import {
   resetContainer,
   testFindTextInContainer,
 } from "@/utils/ui/highlightUtils";
+import { extractTitleFromDescription } from "@/utils/ui/extractTitle";
 
 interface HighlightedMarkdownProps {
   content: string;
@@ -79,8 +80,9 @@ export function HighlightedMarkdown({
         // Enhanced debugging for highlights
         highlights.forEach((highlight, index) => {
           const { startOffset, endOffset, quotedText } = highlight.highlight;
+          const { title } = extractTitleFromDescription(highlight.description);
           console.log(`[HighlightedMarkdown] Highlight ${index}:`, {
-            title: highlight.title,
+            title,
             startOffset,
             endOffset,
             quotedTextPreview: quotedText

--- a/src/lib/documentAnalysis/__tests__/comprehensiveAnalysis.highlights.test.ts
+++ b/src/lib/documentAnalysis/__tests__/comprehensiveAnalysis.highlights.test.ts
@@ -153,8 +153,7 @@ Line 5 has the final content.`;
 
     // Verify comment details
     commentResult.outputs.comments.forEach((comment, index) => {
-      console.log(`Comment ${index + 1}: "${comment.title}"`);
-      expect(comment.title).toBe(analysisResult.outputs.commentInsights[index].title);
+      console.log(`Comment ${index + 1}: "${comment.description.substring(0, 50)}..."`);
       expect(comment.description).toBe(analysisResult.outputs.commentInsights[index].suggestedComment);
       expect(comment.highlight).toBeDefined();
       expect(comment.highlight.startOffset).toBeGreaterThanOrEqual(0);
@@ -293,7 +292,7 @@ Line 5 has the final content.`;
 
     // Should get 2 valid comments, skipping the invalid one
     expect(commentResult.outputs.comments).toHaveLength(2);
-    expect(commentResult.outputs.comments[0].title).toBe("Valid Comment");
-    expect(commentResult.outputs.comments[1].title).toBe("Another Valid");
+    expect(commentResult.outputs.comments[0].description).toBe("Good comment");
+    expect(commentResult.outputs.comments[1].description).toBe("Another good comment");
   });
 });

--- a/src/lib/documentAnalysis/__tests__/comprehensiveAnalysis.llm.test.ts
+++ b/src/lib/documentAnalysis/__tests__/comprehensiveAnalysis.llm.test.ts
@@ -86,14 +86,13 @@ What are your thoughts on AI in education? How can we balance innovation with th
     // Check comments
     expect(result.comments).toHaveLength(targetComments);
     result.comments.forEach((comment, i) => {
-      expect(comment.title).toBeDefined();
       expect(comment.description).toBeDefined();
       expect(comment.highlight).toBeDefined();
       expect(comment.highlight.startOffset).toBeGreaterThanOrEqual(0);
       expect(comment.highlight.endOffset).toBeGreaterThan(comment.highlight.startOffset);
       
       console.log(`Comment ${i + 1}: {
-      title: '${comment.title}',
+      description: '${comment.description.slice(0, 50)}...',
       importance: ${comment.importance},
       quotedText: '${comment.highlight.quotedText.slice(0, 50)}...'
     }`);

--- a/src/lib/documentAnalysis/__tests__/comprehensiveAnalysis.unit.test.ts
+++ b/src/lib/documentAnalysis/__tests__/comprehensiveAnalysis.unit.test.ts
@@ -86,19 +86,17 @@ Overall, this is a well-structured test document.
               commentInsights: [
                 {
                   id: "insight-1",
-                  title: "Opening Line Analysis",
                   location: "Lines 1",
                   observation: "The opening line clearly states the document's purpose",
                   significance: "Sets expectations for the reader",
-                  suggestedComment: "The opening line effectively establishes context",
+                  suggestedComment: "Opening Line Analysis. The opening line effectively establishes context",
                 },
                 {
                   id: "insight-2",
-                  title: "Structure Review",
                   location: "Lines 2-3",
                   observation: "The document maintains consistent structure",
                   significance: "Easy to follow and understand",
-                  suggestedComment: "The structural consistency aids readability",
+                  suggestedComment: "Structure Review. The structural consistency aids readability",
                 },
               ],
             },
@@ -134,19 +132,17 @@ Overall, this is a well-structured test document.
         commentInsights: [
           {
             id: "insight-1",
-            title: "Test Comment 1",
             location: "Lines 1",
             observation: "First observation",
             significance: "Why it matters",
-            suggestedComment: "This is the first comment text",
+            suggestedComment: "Test Comment 1. This is the first comment text",
           },
           {
             id: "insight-2",
-            title: "Test Comment 2",
             location: "Lines 2-3",
             observation: "Second observation",
             significance: "Also important",
-            suggestedComment: "This is the second comment text",
+            suggestedComment: "Test Comment 2. This is the second comment text",
           },
         ],
       };
@@ -159,8 +155,7 @@ Overall, this is a well-structured test document.
       );
 
       expect(result.outputs.comments).toHaveLength(2);
-      expect(result.outputs.comments[0].title).toBe("Test Comment 1");
-      expect(result.outputs.comments[0].description).toBe("This is the first comment text");
+      expect(result.outputs.comments[0].description).toBe("Test Comment 1. This is the first comment text");
       expect(result.outputs.comments[0].highlight.startOffset).toBeDefined();
       expect(result.outputs.comments[0].highlight.endOffset).toBeDefined();
       expect(result.task.name).toBe("extractCommentsFromAnalysis");
@@ -182,8 +177,7 @@ Overall, this is a well-structured test document.
             input: {
               comments: [
                 {
-                  title: "Extracted Comment",
-                  description: "Comment extracted via LLM",
+                  description: "Extracted Comment. Comment extracted via LLM",
                   importance: 5,
                   highlight: {
                     startLineIndex: 0,
@@ -213,7 +207,7 @@ Overall, this is a well-structured test document.
       );
 
       expect(result.outputs.comments).toHaveLength(1);
-      expect(result.outputs.comments[0].title).toBe("Extracted Comment");
+      expect(result.outputs.comments[0].description).toContain("Extracted Comment");
       expect(result.task.priceInCents).toBeGreaterThan(0); // Should have cost for LLM
     });
   });

--- a/src/lib/documentAnalysis/analyzeDocument.ts
+++ b/src/lib/documentAnalysis/analyzeDocument.ts
@@ -7,6 +7,7 @@ import { generateComprehensiveAnalysis } from "./comprehensiveAnalysis";
 import { analyzeLinkDocument } from "./linkAnalysis/linkAnalysisWorkflow";
 import { generateSelfCritique } from "./selfCritique";
 import type { TaskResult } from "./shared/types";
+import { extractTitleFromDescription } from "../../utils/ui/extractTitle";
 
 export async function analyzeDocument(
   document: Document,
@@ -71,10 +72,13 @@ export async function analyzeDocument(
           summary: analysisResult.outputs.summary,
           analysis: analysisResult.outputs.analysis,
           grade: analysisResult.outputs.grade,
-          comments: commentResult.outputs.comments.map((c) => ({
-            title: c.highlight?.quotedText || "Comment",
-            text: c.description,
-          })),
+          comments: commentResult.outputs.comments.map((c) => {
+            const { title } = extractTitleFromDescription(c.description);
+            return {
+              title: title || c.highlight?.quotedText?.substring(0, 50) || "Comment",
+              text: c.description,
+            };
+          }),
         },
         agentInfo
       );

--- a/src/lib/documentAnalysis/commentExtraction/index.ts
+++ b/src/lib/documentAnalysis/commentExtraction/index.ts
@@ -96,7 +96,6 @@ export async function extractCommentsFromAnalysis(
       }
       
       const lineBasedComment: LineBasedComment = {
-        title: insight.title,
         description: insight.suggestedComment,
         importance: 5, // Default importance
         highlight: {
@@ -193,13 +192,9 @@ export async function extractCommentsFromAnalysis(
                   items: {
                     type: "object",
                     properties: {
-                      title: {
-                        type: "string",
-                        description: "Clear, descriptive title (max 80 characters)",
-                      },
                       description: {
                         type: "string",
-                        description: "Comment body text (100-300 words)",
+                        description: "Comment text (100-300 words) starting with a clear, concise statement of the main point",
                       },
                       highlight: {
                         type: "object",
@@ -224,7 +219,7 @@ export async function extractCommentsFromAnalysis(
                         required: ["startLineIndex", "endLineIndex", "startCharacters", "endCharacters"],
                       },
                     },
-                    required: ["title", "description", "highlight"],
+                    required: ["description", "highlight"],
                   },
                 },
               },
@@ -246,7 +241,9 @@ export async function extractCommentsFromAnalysis(
     const result = toolUse.input as { comments: LineBasedComment[] };
     
     // Convert line-based to character-based comments
-    comments = await validateAndConvertComments(result.comments, document.content);
+    // Get the full content with prepend (same as what was shown to the LLM)
+    const { content: fullContent } = getDocumentFullContent(document);
+    comments = await validateAndConvertComments(result.comments, fullContent);
 
   } catch (error: any) {
     logger.error('Error in comment extraction:', error);

--- a/src/lib/documentAnalysis/commentExtraction/prompts.ts
+++ b/src/lib/documentAnalysis/commentExtraction/prompts.ts
@@ -54,11 +54,13 @@ Look for the "Key Insights for Commentary" section in the analysis, which contai
 - Suggested comment text
 
 Convert these insights into properly formatted comments with:
-- Clear, descriptive titles (max 80 characters)
-- Well-written body text (100-300 words)
+- Well-written descriptions (100-300 words) that begin with a clear, concise statement of the main point
 - Correct line number references (startLine and endLine)
+- The description should be self-contained and include all necessary context
 
-If the analysis doesn't have a clear "Key Insights" section, identify the most important observations from the analysis and create comments for those.`;
+If the analysis doesn't have a clear "Key Highlights" section, identify the most important observations from the analysis and create comments for those.
+
+IMPORTANT: Start each description with a strong, clear statement that summarizes the key point (like a title would), then expand with details.`;
 
   return { systemMessage, userMessage };
 }

--- a/src/lib/documentAnalysis/commentGeneration/__tests__/lineBasedHighlighter.test.ts
+++ b/src/lib/documentAnalysis/commentGeneration/__tests__/lineBasedHighlighter.test.ts
@@ -76,9 +76,8 @@ When I started this blog in high school, I did not imagine that I would cause [_
 
     const lineComments: LineBasedComment[] = [
       {
-        title: "Opening Hook",
         description:
-          "Great opening that connects personal story to broader impact",
+          "Opening Hook. Great opening that connects personal story to broader impact",
         importance: 8,
         highlight: {
           startLineIndex: 0,
@@ -93,7 +92,7 @@ When I started this blog in high school, I did not imagine that I would cause [_
 
     expect(processedComments).toHaveLength(1);
     expect(processedComments[0].isValid).toBe(true);
-    expect(processedComments[0].title).toBe("Opening Hook");
+    expect(processedComments[0].description).toContain("Opening Hook");
     expect(processedComments[0].highlight.isValid).toBe(true);
     expect(processedComments[0].highlight.quotedText).toContain("Crossposted");
   });

--- a/src/lib/documentAnalysis/commentGeneration/commentValidator.ts
+++ b/src/lib/documentAnalysis/commentGeneration/commentValidator.ts
@@ -14,7 +14,6 @@ export function normalizeComments(
   rawComments: RawLLMComment[]
 ): LineBasedComment[] {
   return rawComments.map((comment) => ({
-    title: comment.title,
     description: comment.description,
     highlight: comment.highlight,
     importance: comment.importance ?? 50,
@@ -35,9 +34,6 @@ export async function validateAndConvertComments(
 
   // Validate the raw comment structure
   const rawComments: LineBasedComment[] = comments.map((comment, index) => {
-    if (!comment.title || typeof comment.title !== "string") {
-      throw new Error(`Comment ${index} missing or invalid title`);
-    }
     if (!comment.description || typeof comment.description !== "string") {
       throw new Error(`Comment ${index} missing or invalid description`);
     }
@@ -96,7 +92,6 @@ export async function validateAndConvertComments(
     }
 
     return {
-      title: comment.title,
       description: comment.description,
       highlight: highlight as LineSnippetHighlight,
       importance: comment.importance,
@@ -120,7 +115,7 @@ export async function validateAndConvertComments(
 
       if (!comment.isValid) {
         throw new Error(
-          `Comment ${index} failed highlight processing: ${comment.title}`
+          `Comment ${index} failed highlight processing`
         );
       }
 

--- a/src/lib/documentAnalysis/commentGeneration/lineBasedHighlighter.ts
+++ b/src/lib/documentAnalysis/commentGeneration/lineBasedHighlighter.ts
@@ -415,7 +415,6 @@ export class LineBasedHighlighter {
 
       if (highlightResult) {
         const processedComment: Comment = {
-          title: comment.title,
           description: comment.description,
           importance: comment.importance || 5,
           grade: comment.grade,
@@ -432,7 +431,6 @@ export class LineBasedHighlighter {
       } else {
         // Create invalid comment for debugging
         const invalidComment: Comment = {
-          title: comment.title,
           description: comment.description,
           importance: comment.importance || 5,
           grade: comment.grade,

--- a/src/lib/documentAnalysis/commentGeneration/types.ts
+++ b/src/lib/documentAnalysis/commentGeneration/types.ts
@@ -4,7 +4,6 @@ import type { LineSnippetHighlight } from "./lineBasedHighlighter";
 
 // Response from Anthropic API
 export interface RawLLMComment {
-  title: string;
   description: string;
   highlight: LineSnippetHighlight;
   importance?: number;
@@ -13,7 +12,6 @@ export interface RawLLMComment {
 
 // Validated comment with line-based highlight
 export interface LineBasedComment {
-  title: string;
   description: string;
   importance: number;
   grade?: number;

--- a/src/lib/documentAnalysis/comprehensiveAnalysis/index.ts
+++ b/src/lib/documentAnalysis/comprehensiveAnalysis/index.ts
@@ -30,7 +30,6 @@ export interface ComprehensiveAnalysisOutputs {
 
 export interface CommentInsight {
   id: string;
-  title: string;
   location: string; // Line reference like "Lines 45-52" or "Line 78"
   observation: string;
   significance: string;

--- a/src/lib/documentAnalysis/comprehensiveAnalysis/prompts.ts
+++ b/src/lib/documentAnalysis/comprehensiveAnalysis/prompts.ts
@@ -20,15 +20,16 @@ Structure your response as a markdown document (${targetWordCount}+ words) with:
 
 For the Key Highlights section, use this format for each comment:
 
-### Highlight [#]: [Title]
+### Highlight [#]
 - **Location**: Line X or Lines X-Y
 - **Context**: What this passage is about
-- **Your Contribution**: Your specific comment/insight/resource (100-300 words)
+- **Your Contribution**: Your specific comment/insight/resource (100-300 words). Start with a clear summary sentence that captures the main point, then provide your detailed analysis.
 
 Important formatting notes:
 - Use single line numbers like "Line 42" or ranges like "Lines 156-162"
 - Number highlights sequentially (Highlight 1, Highlight 2, etc.)
 - Make your contributions specific and actionable
+- Begin each contribution with a strong opening sentence that summarizes the key point
 - Use markdown formatting (headers, lists, emphasis, code blocks) throughout
 
 ${agentInfo.providesGrades ? "\nInclude a grade (0-100) with justification based on your grading criteria." : ""}`;

--- a/src/lib/documentAnalysis/linkAnalysis/__tests__/linkAnalysis.e2e.test.ts
+++ b/src/lib/documentAnalysis/linkAnalysis/__tests__/linkAnalysis.e2e.test.ts
@@ -96,7 +96,7 @@ describe("Link Analysis End-to-End Tests", () => {
         // Log comment details
         console.log("💬 Comments with grades:");
         result.comments.forEach((comment, commentIndex) => {
-          console.log(`  ${commentIndex + 1}. ${comment.title} (Grade: ${comment.grade}/100)`);
+          console.log(`  ${commentIndex + 1}. ${comment.description.substring(0, 50)}... (Grade: ${comment.grade}/100)`);
         });
 
         // Grade validation for each comment if we have grade range expectations
@@ -114,9 +114,9 @@ describe("Link Analysis End-to-End Tests", () => {
 
       // Status validation based on expected link status
       if (testCase.expectedLinkStatus === "working") {
-        expect(result.comments.some(c => c.title.includes("✅"))).toBe(true);
+        expect(result.comments.some(c => c.description.includes("✅"))).toBe(true);
       } else if (testCase.expectedLinkStatus === "broken") {
-        expect(result.comments.some(c => c.title.includes("❌"))).toBe(true);
+        expect(result.comments.some(c => c.description.includes("❌"))).toBe(true);
       }
 
       // Document-level grade validation

--- a/src/lib/documentAnalysis/linkAnalysis/linkAnalysisWorkflow.ts
+++ b/src/lib/documentAnalysis/linkAnalysis/linkAnalysisWorkflow.ts
@@ -148,7 +148,6 @@ function generateLinkComments(
       const linkResult = linkResultMap.get(url);
 
       if (linkResult) {
-        let title: string;
         let grade: number;
         let importance: number;
         let description: string;
@@ -157,43 +156,37 @@ function generateLinkComments(
           // Handle different error types
           switch (linkResult.accessError.type) {
             case "NotFound":
-              title = `❌ Broken link`;
               grade = 0;
               importance = 100;
-              description = `${url} - Page not found (HTTP 404)`;
+              description = `❌ Broken link: ${url} - Page not found (HTTP 404)`;
               break;
             case "Forbidden":
-              title = `🚫 Access denied`;
               grade = 0;
               importance = 100;
-              description = `${url} - Access forbidden (HTTP 403)`;
+              description = `🚫 Access denied: ${url} - Access forbidden (HTTP 403)`;
               break;
             case "Timeout":
-              title = `⏱️ Link timeout`;
               grade = 0;
               importance = 100;
-              description = `${url} - Request timed out`;
+              description = `⏱️ Link timeout: ${url} - Request timed out`;
               break;
             default:
-              title = `❌ Link error`;
               grade = 0;
               importance = 100;
               const errorMsg =
                 "message" in linkResult.accessError
                   ? linkResult.accessError.message
                   : "Unknown error";
-              description = `${url} - ${errorMsg}`;
+              description = `❌ Link error: ${url} - ${errorMsg}`;
           }
         } else {
           // URL is accessible - simple verification
-          title = `✅ Link verified`;
           grade = 90;
           importance = 10;
-          description = `${url} - Server responded successfully (HTTP 200)`;
+          description = `✅ Link verified: ${url} - Server responded successfully (HTTP 200)`;
         }
 
         comments.push({
-          title,
           description,
           highlight: urlPosition,
           importance,

--- a/src/lib/evaluation/exportXml.ts
+++ b/src/lib/evaluation/exportXml.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib/logger";
+import { extractTitleFromDescription } from "@/utils/ui/extractTitle";
 
 interface ExportEvaluationData {
   evaluation: {
@@ -115,7 +116,8 @@ export function exportEvaluationToXml(data: ExportEvaluationData): string {
     evaluation.comments.forEach(comment => {
       xml += '    <comment>\n';
       xml += `      <id>${comment.id}</id>\n`;
-      xml += `      <title>${escapeXml(comment.title)}</title>\n`;
+      const { title } = extractTitleFromDescription(comment.description);
+      xml += `      <title>${escapeXml(title)}</title>\n`;
       xml += `      <description><![CDATA[${comment.description}]]></description>\n`;
       if (comment.importance !== null && comment.importance !== undefined) {
         xml += `      <importance>${comment.importance}</importance>\n`;

--- a/src/models/Agent.ts
+++ b/src/models/Agent.ts
@@ -403,7 +403,6 @@ export class AgentModel {
           comments: {
             select: {
               id: true,
-              title: true,
               description: true,
               importance: true,
               grade: true,

--- a/src/models/Document.ts
+++ b/src/models/Document.ts
@@ -61,7 +61,6 @@ type DocumentWithRelations = {
       selfCritique: string | null;
       comments: Array<{
         id: string;
-        title: string;
         description: string;
         importance: number | null;
         grade: number | null;
@@ -220,7 +219,6 @@ export class DocumentModel {
               }
             : undefined,
           comments: version.comments.map((comment) => ({
-            title: comment.title,
             description: comment.description,
             importance: comment.importance || undefined,
             grade: comment.grade || undefined,
@@ -269,7 +267,6 @@ export class DocumentModel {
           costInCents: evaluation.versions[0]?.job?.costInCents || 0,
           comments:
             evaluation.versions[0]?.comments.map((comment) => ({
-              title: comment.title,
               description: comment.description,
               importance: comment.importance || undefined,
               grade: comment.grade || undefined,
@@ -343,7 +340,6 @@ export class DocumentModel {
               }
             : undefined,
           comments: version.comments.map((comment: any) => ({
-            title: comment.title,
             description: comment.description,
             importance: comment.importance || undefined,
             grade: comment.grade || undefined,
@@ -394,7 +390,6 @@ export class DocumentModel {
           costInCents: evaluation.versions[0]?.job?.costInCents || 0,
           comments:
             evaluation.versions[0]?.comments.map((comment: any) => ({
-              title: comment.title,
               description: comment.description,
               importance: comment.importance || undefined,
               grade: comment.grade || undefined,

--- a/src/models/Job.ts
+++ b/src/models/Job.ts
@@ -465,7 +465,6 @@ export class JobModel {
           // Create comment linked to highlight
           await prisma.evaluationComment.create({
             data: {
-              title: comment.title,
               description: comment.description,
               importance: comment.importance || null,
               grade: comment.grade || null,

--- a/src/scripts/verify-highlights.ts
+++ b/src/scripts/verify-highlights.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import { logger } from "@/lib/logger";
 import { readdir, readFile } from "fs/promises";
 import path from "path";
+import { extractTitleFromDescription } from "../utils/ui/extractTitle";
 
 const program = new Command();
 
@@ -200,18 +201,20 @@ async function verifyFile(filePath: string) {
 
       for (const comment of review.comments) {
         totalHighlights++;
+        const { title } = extractTitleFromDescription(comment.description || "");
+        const displayTitle = title || comment.highlight?.quotedText?.substring(0, 50) || "Untitled";
         const result = verifyHighlight(
           document.content,
           comment.highlight,
-          comment.title
+          displayTitle
         );
 
         if (result.isValid) {
           validHighlights++;
-          console.log(`✅ Valid highlight: "${comment.title}"`);
+          console.log(`✅ Valid highlight: "${displayTitle}"`);
         } else {
           invalidHighlights++;
-          console.log(`❌ Invalid highlight: "${comment.title}"`);
+          console.log(`❌ Invalid highlight: "${displayTitle}"`);
           console.log(`   Error: ${result.error}`);
           console.log(`   Expected: "${result.expectedText}"`);
           console.log(`   Found:    "${result.foundText}"`);

--- a/src/types/documentSchema.ts
+++ b/src/types/documentSchema.ts
@@ -13,7 +13,6 @@ export type Highlight = z.infer<typeof HighlightSchema>;
 
 // Schema for document comment
 export const CommentSchema = z.object({
-  title: z.string(),
   description: z.string(),
   importance: z.number().optional(),
   grade: z.number().optional(),

--- a/src/utils/ui/__tests__/highlightUtils.test.ts
+++ b/src/utils/ui/__tests__/highlightUtils.test.ts
@@ -1,7 +1,4 @@
-import type {
-  Comment,
-  Highlight,
-} from "../../../types/documentSchema";
+import type { Comment, Highlight } from "../../../types/documentSchema";
 import {
   fixOverlappingHighlights,
   highlightsOverlap,
@@ -63,7 +60,6 @@ describe("UI Helper Functions", () => {
   test("fixes overlapping highlights", () => {
     const comments: Comment[] = [
       {
-        title: "First",
         description: "First comment",
         importance: 5,
         highlight: {
@@ -75,7 +71,6 @@ describe("UI Helper Functions", () => {
         isValid: true,
       },
       {
-        title: "Overlapping",
         description: "Overlapping comment",
         importance: 5,
         highlight: {
@@ -87,7 +82,6 @@ describe("UI Helper Functions", () => {
         isValid: true,
       },
       {
-        title: "Separate",
         description: "Separate comment",
         importance: 5,
         highlight: {
@@ -103,7 +97,7 @@ describe("UI Helper Functions", () => {
     const fixed = fixOverlappingHighlights(comments);
 
     expect(fixed).toHaveLength(2);
-    expect(fixed[0].title).toBe("First");
-    expect(fixed[1].title).toBe("Separate");
+    expect(fixed[0].description).toBe("First comment");
+    expect(fixed[1].description).toBe("Separate comment");
   });
 });

--- a/src/utils/ui/commentUtils.tsx
+++ b/src/utils/ui/commentUtils.tsx
@@ -55,7 +55,6 @@ export function filterValidComments(comments: Comment[]): Comment[] {
   return comments.filter(
     (comment) =>
       comment.highlight &&
-      comment.title &&
       comment.description &&
       (comment.isValid === undefined || comment.isValid === true)
   );

--- a/src/utils/ui/extractTitle.ts
+++ b/src/utils/ui/extractTitle.ts
@@ -1,0 +1,61 @@
+/**
+ * Extracts a title from a markdown description by using the first line
+ * or the first part up to a period, whichever is shorter.
+ * Falls back to truncating the description if no good break point is found.
+ */
+export function extractTitleFromDescription(description: string): {
+  title: string;
+  remainingDescription: string;
+} {
+  if (!description) {
+    return { title: "", remainingDescription: "" };
+  }
+
+  // Remove leading/trailing whitespace
+  const trimmed = description.trim();
+  
+  // Check if the description starts with a markdown header
+  const headerMatch = trimmed.match(/^#{1,6}\s+(.+?)(\n|$)/);
+  if (headerMatch) {
+    const title = headerMatch[1].trim();
+    const remainingDescription = trimmed.substring(headerMatch[0].length).trim();
+    return { title, remainingDescription };
+  }
+
+  // Find the first line break or period, whichever comes first
+  const firstNewline = trimmed.indexOf('\n');
+  const firstPeriod = trimmed.indexOf('. ');
+  
+  let titleEnd = -1;
+  
+  // If we have both, use whichever comes first
+  if (firstNewline !== -1 && firstPeriod !== -1) {
+    titleEnd = Math.min(firstNewline, firstPeriod + 1);
+  } else if (firstNewline !== -1) {
+    titleEnd = firstNewline;
+  } else if (firstPeriod !== -1) {
+    titleEnd = firstPeriod + 1;
+  }
+  
+  // If we found a good break point and it's not too long
+  if (titleEnd !== -1 && titleEnd <= 150) {
+    const title = trimmed.substring(0, titleEnd).trim();
+    const remainingDescription = trimmed.substring(titleEnd).trim();
+    return { title, remainingDescription };
+  }
+  
+  // If the whole description is short, use it as the title
+  if (trimmed.length <= 100) {
+    return { title: trimmed, remainingDescription: "" };
+  }
+  
+  // Otherwise, truncate at a reasonable length
+  const truncateAt = 80;
+  const lastSpace = trimmed.lastIndexOf(' ', truncateAt);
+  const cutPoint = lastSpace > 40 ? lastSpace : truncateAt;
+  
+  return {
+    title: trimmed.substring(0, cutPoint) + "...",
+    remainingDescription: trimmed.substring(cutPoint).trim()
+  };
+}

--- a/src/utils/ui/highlightUtils.ts
+++ b/src/utils/ui/highlightUtils.ts
@@ -1,4 +1,5 @@
 import type { Comment, Evaluation, Highlight } from "../../types/documentSchema";
+import { extractTitleFromDescription } from "./extractTitle";
 
 /**
  * Checks if two highlights overlap
@@ -160,7 +161,8 @@ export function applyHighlightsToContainer(
 
   for (const comment of validHighlights) {
     const { quotedText } = comment.highlight;
-    const color = colorMap[comment.title] || "#ffeb3b";
+    const { title } = extractTitleFromDescription(comment.description);
+    const color = colorMap[title] || "#ffeb3b";
 
     try {
       // Find text nodes that contain our highlight
@@ -179,7 +181,7 @@ export function applyHighlightsToContainer(
         node,
         nodeOffset,
         nodeOffset + highlightLength,
-        comment.title,
+        title,
         color
       );
 
@@ -245,7 +247,8 @@ export function fixOverlappingHighlights(comments: Comment[]): Comment[] {
     if (!hasOverlap) {
       fixed.push(comment);
     } else {
-      console.warn(`Removing overlapping highlight: ${comment.title}`);
+      const { title } = extractTitleFromDescription(comment.description);
+      console.warn(`Removing overlapping highlight: ${title}`);
     }
   }
 
@@ -263,7 +266,8 @@ export function validateHighlights(review: Evaluation): {
 
   for (const comment of review.comments) {
     if (!comment.highlight.isValid) {
-      errors.push(`Invalid highlight for comment: ${comment.title}`);
+      const { title } = extractTitleFromDescription(comment.description);
+      errors.push(`Invalid highlight for comment: ${title}`);
     }
   }
 


### PR DESCRIPTION
- Remove title column from database schema
- Update all TypeScript types and interfaces
- Create extractTitleFromDescription utility for UI consistency
- Update comment generation prompts to use markdown formatting
- Fix all references across components and tests
- Migration drops title column (no data migration needed per requirements)

BREAKING CHANGE: EvaluationComment no longer has a title field. Comments now use markdown formatting in descriptions.

🤖 Generated with [Claude Code](https://claude.ai/code)