### PR TITLE
Add Google Fonts support for reader view

### DIFF
--- a/config/jest/jest.config.cjs
+++ b/config/jest/jest.config.cjs
@@ -50,6 +50,7 @@ module.exports = {
     "^next-auth$": "<rootDir>/src/__mocks__/next-auth.js",
     "^next-auth/providers/resend$": "<rootDir>/src/__mocks__/next-auth/providers/resend.js",
     "^@auth/prisma-adapter$": "<rootDir>/src/__mocks__/@auth/prisma-adapter.js",
+    "^next/font/google$": "<rootDir>/src/__mocks__/next/font/google.js",
   },
   extensionsToTreatAsEsm: [".ts", ".tsx"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],

--- a/src/__mocks__/next/font/google.js
+++ b/src/__mocks__/next/font/google.js
@@ -1,0 +1,14 @@
+// Mock for next/font/google
+const createFontMock = (name) => ({
+  style: {
+    fontFamily: `'${name}', serif`,
+  },
+  className: `font-${name.toLowerCase()}`,
+  variable: `--font-${name.toLowerCase()}`,
+});
+
+module.exports = {
+  Merriweather: () => createFontMock('Merriweather'),
+  Libre_Baskerville: () => createFontMock('Libre Baskerville'),
+  // Add other fonts as needed
+};

--- a/src/components/SlateEditor.tsx
+++ b/src/components/SlateEditor.tsx
@@ -31,6 +31,7 @@ import { unified } from "unified";
 // Import our improved hooks for Phase 2
 import { useHighlightMapper } from "@/hooks/useHighlightMapper";
 import { usePlainTextOffsets } from "@/hooks/usePlainTextOffsets";
+import { readerFontFamily } from "@/lib/fonts";
 
 // Helper function to normalize text by removing markdown formatting
 const normalizeText = (text: string): string => {
@@ -634,8 +635,7 @@ const SlateEditor: React.FC<SlateEditorProps> = ({
   return (
     <div
       style={{
-        fontFamily:
-          "Merriweather, Baskerville, Libre Baskerville, Georgia, serif",
+        fontFamily: readerFontFamily,
       }}
     >
       <Slate editor={editor} initialValue={value}>

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,0 +1,18 @@
+import { Merriweather, Libre_Baskerville } from 'next/font/google';
+
+export const merriweather = Merriweather({
+  weight: ['300', '400', '700', '900'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-merriweather',
+});
+
+export const libreBaskerville = Libre_Baskerville({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-libre-baskerville',
+});
+
+// Combined font stack for reader view
+export const readerFontFamily = `${merriweather.style.fontFamily}, ${libreBaskerville.style.fontFamily}, Baskerville, Georgia, serif`;


### PR DESCRIPTION
## Summary
- Adds Merriweather and Libre Baskerville fonts for the reader view
- Uses Next.js built-in font optimization for Docker compatibility
- Fonts are downloaded at build time and self-hosted

## Implementation Details
- Created `/src/lib/fonts.ts` to configure Google Fonts using `next/font`
- Updated `SlateEditor.tsx` to use the configured font stack
- Fonts are automatically optimized with proper fallbacks (Baskerville, Georgia, serif)

## Benefits
- No runtime Google Fonts requests (privacy + performance)
- Works in Docker builds (no external requests during build)
- Automatic font subsetting and optimization by Next.js
- Proper font-display: swap for better loading experience

## Test plan
- [x] Verified fonts load correctly in development
- [x] Confirmed no build errors
- [x] Tested reader view at `/docs/[docId]/reader`

🤖 Generated with [Claude Code](https://claude.ai/code)