### PR TITLE
Fix Docker build failure from npm scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apk add --no-cache libc6-compat python3 make g++
 COPY package*.json ./
 COPY prisma ./prisma/
 
+# Copy scripts directory for npm scripts that reference them
+COPY scripts ./scripts/
+
 # Install all dependencies
 RUN npm ci
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -9,6 +9,9 @@ RUN apk add --no-cache libc6-compat python3 make g++
 COPY package*.json ./
 COPY prisma ./prisma/
 
+# Copy scripts directory for npm scripts that reference them
+COPY scripts ./scripts/
+
 # Install all dependencies (including dev dependencies for tsx)
 RUN npm ci
 


### PR DESCRIPTION
## Summary
Fixes the Docker build failure that occurred when the worktree management PR was merged.

## Problem
The npm scripts added in #49 reference shell scripts in the ./scripts directory:
- `"worktree:create": "./scripts/worktree-manager.sh create"`
- etc.

During Docker build, `npm ci` runs before the source code is copied, so these scripts don't exist yet, causing the build to fail.

## Solution
Copy the scripts directory before running `npm ci` in both Dockerfiles.

## Test plan
- [ ] Docker build should succeed
- [ ] GitHub Actions CI should pass

🤖 Generated with [Claude Code](https://claude.ai/code)