### PR TITLE
Remove worktree npm scripts to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN apk add --no-cache libc6-compat python3 make g++
 COPY package*.json ./
 COPY prisma ./prisma/
 
-# Copy scripts directory for npm scripts that reference them
-COPY scripts ./scripts/
-
 # Install all dependencies
 RUN npm ci
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -9,9 +9,6 @@ RUN apk add --no-cache libc6-compat python3 make g++
 COPY package*.json ./
 COPY prisma ./prisma/
 
-# Copy scripts directory for npm scripts that reference them
-COPY scripts ./scripts/
-
 # Install all dependencies (including dev dependencies for tsx)
 RUN npm ci
 

--- a/docs/development/worktrees.md
+++ b/docs/development/worktrees.md
@@ -182,6 +182,10 @@ You can run multiple worktrees simultaneously:
 ./scripts/worktree-manager.sh remove feature-new-ui
 ```
 
+## Note on npm Scripts
+
+The worktree management scripts are standalone shell scripts and are intentionally **not** included as npm scripts. This prevents issues with Docker builds and keeps them as development-only tools. Always use the direct script paths as shown above.
+
 ## Implementation Details
 
 The worktree system consists of:

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "process-jobs-adaptive": "tsx src/scripts/process-jobs-adaptive.ts",
     "cleanup-stale-jobs": "tsx src/scripts/cleanup-stale-jobs.ts",
     "set-admin": "npx tsx scripts/set-admin.ts",
-    "worktree:create": "./scripts/worktree-manager.sh create",
-    "worktree:start": "./scripts/worktree-manager.sh start",
-    "worktree:list": "./scripts/worktree-manager.sh list",
-    "worktree:ports": "./scripts/worktree-manager.sh ports",
-    "worktree": "./scripts/worktree-manager.sh"
+    "worktree:create": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh create || echo 'Worktree scripts not available'",
+    "worktree:start": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh start || echo 'Worktree scripts not available'",
+    "worktree:list": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh list || echo 'Worktree scripts not available'",
+    "worktree:ports": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh ports || echo 'Worktree scripts not available'",
+    "worktree": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh || echo 'Worktree scripts not available'"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.54.0",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,7 @@
     "process-jobs-parallel": "tsx src/scripts/process-jobs-parallel.ts",
     "process-jobs-adaptive": "tsx src/scripts/process-jobs-adaptive.ts",
     "cleanup-stale-jobs": "tsx src/scripts/cleanup-stale-jobs.ts",
-    "set-admin": "npx tsx scripts/set-admin.ts",
-    "worktree:create": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh create || echo 'Worktree scripts not available'",
-    "worktree:start": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh start || echo 'Worktree scripts not available'",
-    "worktree:list": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh list || echo 'Worktree scripts not available'",
-    "worktree:ports": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh ports || echo 'Worktree scripts not available'",
-    "worktree": "test -f scripts/worktree-manager.sh && scripts/worktree-manager.sh || echo 'Worktree scripts not available'"
+    "set-admin": "npx tsx scripts/set-admin.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.54.0",


### PR DESCRIPTION
## Summary
Fixes the Docker build failures by removing the npm scripts that reference worktree shell scripts.

## Problem
The worktree management npm scripts added in #49 were causing Docker builds to fail because they reference shell scripts that aren't needed for production builds.

## Solution
- Removed all `worktree:*` npm scripts from package.json
- Reverted unnecessary Dockerfile changes
- Updated documentation to clarify these are standalone development scripts

## Benefits
- ✅ Docker builds work again
- ✅ Worktree scripts remain fully functional as direct calls
- ✅ Cleaner separation between development and production dependencies

The worktree system works exactly the same - just use `./scripts/worktree-manager.sh` directly.

🤖 Generated with [Claude Code](https://claude.ai/code)