### PR TITLE
Fix reader page showing empty when no evaluations exist

### DIFF
--- a/src/app/docs/[docId]/reader/page.tsx
+++ b/src/app/docs/[docId]/reader/page.tsx
@@ -49,7 +49,7 @@ export default async function DocumentPage({
   return (
     <div className="flex h-full flex-col overflow-hidden bg-gray-50">
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1">
           <DocumentWithEvaluations document={document} isOwner={isOwner} />
         </div>
       </div>

--- a/src/components/DocumentWithEvaluations/components/DocumentMetadata.tsx
+++ b/src/components/DocumentWithEvaluations/components/DocumentMetadata.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
+import type { Document } from "@/types/documentSchema";
+
+interface DocumentMetadataProps {
+  document: Document;
+  showDetailedAnalysisLink?: boolean;
+}
+
+export function DocumentMetadata({ 
+  document, 
+  showDetailedAnalysisLink = false 
+}: DocumentMetadataProps) {
+  return (
+    <div className="flex items-center justify-between px-6">
+      <div className="flex items-center gap-4 text-sm text-gray-600">
+        {document.submittedBy && (
+          <span>
+            Uploaded from{" "}
+            <Link
+              href={`/users/${document.submittedBy.id}`}
+              className="text-blue-600 hover:underline"
+            >
+              {document.submittedBy.name ||
+                document.submittedBy.email ||
+                "Unknown"}
+            </Link>{" "}
+            on {new Date(document.updatedAt).toLocaleDateString()}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <Link
+          href={`/docs/${document.id}`}
+          className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
+        >
+          {showDetailedAnalysisLink ? "Detailed Analysis" : "Document Details"}
+        </Link>
+        {(document.importUrl || document.url) && (
+          <Link
+            href={document.importUrl || document.url}
+            target="_blank"
+            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
+          >
+            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+            Source
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
+++ b/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
@@ -22,35 +22,33 @@ export function EmptyEvaluationsView({
 
   return (
     <div className="flex h-full flex-col overflow-x-hidden">
-      {/* Message banner at the top */}
-      <div className="mx-5 mt-3 rounded-lg border border-blue-200 bg-blue-50 p-4">
-        <div className="flex items-center gap-2">
-          <InformationCircleIcon className="h-5 w-5 text-blue-600" />
-          <p className="text-sm text-blue-800">
-            {isOwner ? (
-              <>
-                This document has no evaluations.{" "}
-                <Link
-                  href={`/docs/${document.id}`}
-                  className="font-medium text-blue-900 hover:underline"
-                >
-                  Add some here
-                </Link>
-                .
-              </>
-            ) : (
-              "This document doesn't have any evaluations, but you can still read the content below."
-            )}
-          </p>
-        </div>
-      </div>
-
-      {/* Main content container */}
+      {/* Unified scroll container for all content */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden pt-2">
         {/* Document content section */}
         <div className="flex min-h-screen justify-center py-5">
           {/* Main content area */}
           <div ref={contentRef} className="relative max-w-3xl flex-1 p-0">
+            {/* Message banner at the top */}
+            <div className="mx-6 mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <InformationCircleIcon className="h-5 w-5 text-blue-600" />
+                  <p className="text-sm text-blue-800">
+                    {isOwner
+                      ? "This document has no evaluations."
+                      : "This document doesn't have any evaluations, but you can still read the content below."}
+                  </p>
+                </div>
+                {isOwner && (
+                  <Link
+                    href={`/docs/${document.id}`}
+                    className="ml-4 inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  >
+                    Add Evaluations
+                  </Link>
+                )}
+              </div>
+            </div>
             {/* Document metadata section */}
             <DocumentMetadata document={document} />
 

--- a/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
+++ b/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
@@ -3,17 +3,20 @@
 import { useRef } from "react";
 import Link from "next/link";
 import SlateEditor from "@/components/SlateEditor";
-import { ArrowTopRightOnSquareIcon, InformationCircleIcon } from "@heroicons/react/20/solid";
+import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type { Document } from "@/types/documentSchema";
+import { DocumentMetadata } from "./DocumentMetadata";
 
 interface EmptyEvaluationsViewProps {
   document: Document;
   contentWithMetadataPrepend: string;
+  isOwner?: boolean;
 }
 
 export function EmptyEvaluationsView({
   document,
   contentWithMetadataPrepend,
+  isOwner = false,
 }: EmptyEvaluationsViewProps) {
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -24,7 +27,20 @@ export function EmptyEvaluationsView({
         <div className="flex items-center gap-2">
           <InformationCircleIcon className="h-5 w-5 text-blue-600" />
           <p className="text-sm text-blue-800">
-            This document hasn't been evaluated yet. You can still read the content below.
+            {isOwner ? (
+              <>
+                This document has no evaluations.{" "}
+                <Link
+                  href={`/docs/${document.id}`}
+                  className="font-medium text-blue-900 hover:underline"
+                >
+                  Add some here
+                </Link>
+                .
+              </>
+            ) : (
+              "This document doesn't have any evaluations, but you can still read the content below."
+            )}
           </p>
         </div>
       </div>
@@ -36,42 +52,7 @@ export function EmptyEvaluationsView({
           {/* Main content area */}
           <div ref={contentRef} className="relative max-w-3xl flex-1 p-0">
             {/* Document metadata section */}
-            <div className="flex items-center justify-between px-6">
-              <div className="flex items-center gap-4 text-sm text-gray-600">
-                {document.submittedBy && (
-                  <span>
-                    Uploaded from{" "}
-                    <Link
-                      href={`/users/${document.submittedBy.id}`}
-                      className="text-blue-600 hover:underline"
-                    >
-                      {document.submittedBy.name ||
-                        document.submittedBy.email ||
-                        "Unknown"}
-                    </Link>{" "}
-                    on {new Date(document.updatedAt).toLocaleDateString()}
-                  </span>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <Link
-                  href={`/docs/${document.id}`}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-                >
-                  Document Details
-                </Link>
-                {(document.importUrl || document.url) && (
-                  <Link
-                    href={document.importUrl || document.url}
-                    target="_blank"
-                    className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-                  >
-                    <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-                    Source
-                  </Link>
-                )}
-              </div>
-            </div>
+            <DocumentMetadata document={document} />
 
             <article className="prose prose-lg prose-slate mx-auto rounded-lg p-8">
               <SlateEditor

--- a/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
+++ b/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRef } from "react";
+import Link from "next/link";
+import SlateEditor from "@/components/SlateEditor";
+import { ArrowTopRightOnSquareIcon, InformationCircleIcon } from "@heroicons/react/20/solid";
+import type { Document } from "@/types/documentSchema";
+
+interface EmptyEvaluationsViewProps {
+  document: Document;
+  contentWithMetadataPrepend: string;
+}
+
+export function EmptyEvaluationsView({
+  document,
+  contentWithMetadataPrepend,
+}: EmptyEvaluationsViewProps) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="flex h-full flex-col overflow-x-hidden">
+      {/* Message banner at the top */}
+      <div className="mx-5 mt-3 rounded-lg border border-blue-200 bg-blue-50 p-4">
+        <div className="flex items-center gap-2">
+          <InformationCircleIcon className="h-5 w-5 text-blue-600" />
+          <p className="text-sm text-blue-800">
+            This document hasn't been evaluated yet. You can still read the content below.
+          </p>
+        </div>
+      </div>
+
+      {/* Main content container */}
+      <div className="flex-1 overflow-y-auto overflow-x-hidden pt-2">
+        {/* Document content section */}
+        <div className="flex min-h-screen justify-center py-5">
+          {/* Main content area */}
+          <div ref={contentRef} className="relative max-w-3xl flex-1 p-0">
+            {/* Document metadata section */}
+            <div className="flex items-center justify-between px-6">
+              <div className="flex items-center gap-4 text-sm text-gray-600">
+                {document.submittedBy && (
+                  <span>
+                    Uploaded from{" "}
+                    <Link
+                      href={`/users/${document.submittedBy.id}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {document.submittedBy.name ||
+                        document.submittedBy.email ||
+                        "Unknown"}
+                    </Link>{" "}
+                    on {new Date(document.updatedAt).toLocaleDateString()}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <Link
+                  href={`/docs/${document.id}`}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
+                >
+                  Document Details
+                </Link>
+                {(document.importUrl || document.url) && (
+                  <Link
+                    href={document.importUrl || document.url}
+                    target="_blank"
+                    className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
+                  >
+                    <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                    Source
+                  </Link>
+                )}
+              </div>
+            </div>
+
+            <article className="prose prose-lg prose-slate mx-auto rounded-lg p-8">
+              <SlateEditor
+                content={contentWithMetadataPrepend}
+                onHighlightHover={() => {}}
+                onHighlightClick={() => {}}
+                highlights={[]}
+                activeTag={null}
+              />
+            </article>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DocumentWithEvaluations/components/EvaluationView.tsx
+++ b/src/components/DocumentWithEvaluations/components/EvaluationView.tsx
@@ -16,10 +16,10 @@ import SlateEditor from "@/components/SlateEditor";
 import { useScrollBehavior } from "../hooks/useScrollBehavior";
 import type { Comment } from "@/types/documentSchema";
 import { getValidAndSortedComments } from "@/utils/ui/commentUtils";
-import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 
 import { EvaluationViewProps } from "../types";
 import { EvaluationCardsHeader } from "./EvaluationCardsHeader";
+import { DocumentMetadata } from "./DocumentMetadata";
 
 export function EvaluationView({
   evaluationState,
@@ -110,42 +110,7 @@ export function EvaluationView({
             {/* Main content area */}
             <div ref={contentRef} className="relative max-w-3xl flex-1 p-0">
               {/* Document metadata section */}
-              <div className="flex items-center justify-between px-6">
-                <div className="flex items-center gap-4 text-sm text-gray-600">
-                  {document.submittedBy && (
-                    <span>
-                      Uploaded from{" "}
-                      <Link
-                        href={`/users/${document.submittedBy.id}`}
-                        className="text-blue-600 hover:underline"
-                      >
-                        {document.submittedBy.name ||
-                          document.submittedBy.email ||
-                          "Unknown"}
-                      </Link>{" "}
-                      on {new Date(document.updatedAt).toLocaleDateString()}
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <Link
-                    href={`/docs/${document.id}`}
-                    className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-                  >
-                    Detailed Analysis
-                  </Link>
-                  {(document.importUrl || document.url) && (
-                    <Link
-                      href={document.importUrl || document.url}
-                      target="_blank"
-                      className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-                    >
-                      <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-                      Source
-                    </Link>
-                  )}
-                </div>
-              </div>
+              <DocumentMetadata document={document} showDetailedAnalysisLink={true} />
 
               <article className="prose prose-lg prose-slate mx-auto rounded-lg p-8">
                 <SlateEditor

--- a/src/components/DocumentWithEvaluations/index.tsx
+++ b/src/components/DocumentWithEvaluations/index.tsx
@@ -11,6 +11,7 @@ import type { DocumentWithReviewsProps, EvaluationState } from "./types";
 
 export function DocumentWithEvaluations({
   document,
+  isOwner = false,
 }: DocumentWithReviewsProps) {
   const hasEvaluations = document.reviews && document.reviews.length > 0;
   
@@ -47,6 +48,7 @@ export function DocumentWithEvaluations({
         <EmptyEvaluationsView
           document={document}
           contentWithMetadataPrepend={contentWithMetadata}
+          isOwner={isOwner}
         />
       )}
     </div>

--- a/src/components/DocumentWithEvaluations/index.tsx
+++ b/src/components/DocumentWithEvaluations/index.tsx
@@ -6,6 +6,7 @@ import { getDocumentFullContent } from "@/utils/documentContentHelpers";
 import { HEADER_HEIGHT_PX } from "@/utils/ui/constants";
 
 import { EvaluationView } from "./components";
+import { EmptyEvaluationsView } from "./components/EmptyEvaluationsView";
 import type { DocumentWithReviewsProps, EvaluationState } from "./types";
 
 export function DocumentWithEvaluations({
@@ -43,14 +44,10 @@ export function DocumentWithEvaluations({
           contentWithMetadataPrepend={contentWithMetadata}
         />
       ) : (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-white p-4">
-          <h1 className="mb-4 text-2xl font-bold text-gray-900">
-            No evaluations available
-          </h1>
-          <p className="mb-8 text-gray-600">
-            This document hasn't been evaluated yet.
-          </p>
-        </div>
+        <EmptyEvaluationsView
+          document={document}
+          contentWithMetadataPrepend={contentWithMetadata}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Fixed issue where reader page showed completely empty content for documents without evaluations
- Added EmptyEvaluationsView component to display document content even when no evaluations are available
- Maintains consistent layout and navigation with evaluation view

## Changes Made
- Created `EmptyEvaluationsView` component that shows full document content with metadata
- Updated `DocumentWithEvaluations` to use new component instead of empty state message
- Added informational banner indicating no evaluations are available
- Preserved all navigation links (Document Details, Source)

## Test Plan
- [x] Verify documents without evaluations now show content in reader view
- [x] Check that all metadata and navigation links work correctly
- [x] Confirm TypeScript compilation passes
- [x] Test layout matches evaluation view styling

🤖 Generated with [Claude Code](https://claude.ai/code)