### PR TITLE
Add evaluation status messages for reader page

### DIFF
--- a/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
+++ b/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
@@ -3,20 +3,32 @@
 import { useRef } from "react";
 import Link from "next/link";
 import SlateEditor from "@/components/SlateEditor";
-import { InformationCircleIcon } from "@heroicons/react/20/solid";
+import { InformationCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/20/solid";
 import type { Document } from "@/types/documentSchema";
 import { DocumentMetadata } from "./DocumentMetadata";
+
+interface FailedJob {
+  id: string;
+  status: string;
+  createdAt: Date;
+  agentName: string;
+  agentId: string;
+}
 
 interface EmptyEvaluationsViewProps {
   document: Document;
   contentWithMetadataPrepend: string;
   isOwner?: boolean;
+  pendingJobsCount?: number;
+  failedJobs?: FailedJob[];
 }
 
 export function EmptyEvaluationsView({
   document,
   contentWithMetadataPrepend,
   isOwner = false,
+  pendingJobsCount = 0,
+  failedJobs = [],
 }: EmptyEvaluationsViewProps) {
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -29,26 +41,67 @@ export function EmptyEvaluationsView({
           {/* Main content area */}
           <div ref={contentRef} className="relative max-w-3xl flex-1 p-0">
             {/* Message banner at the top */}
-            <div className="mx-6 mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4">
-              <div className="flex items-center justify-between">
+            {pendingJobsCount > 0 ? (
+              <div className="mx-6 mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4">
                 <div className="flex items-center gap-2">
-                  <InformationCircleIcon className="h-5 w-5 text-blue-600" />
-                  <p className="text-sm text-blue-800">
-                    {isOwner
-                      ? "This document has no evaluations."
-                      : "This document doesn't have any evaluations, but you can still read the content below."}
+                  <InformationCircleIcon className="h-5 w-5 text-amber-600" />
+                  <p className="text-sm text-amber-800">
+                    Processing {pendingJobsCount} evaluation{pendingJobsCount > 1 ? 's' : ''}... This may take a few moments.
                   </p>
                 </div>
-                {isOwner && (
-                  <Link
-                    href={`/docs/${document.id}`}
-                    className="ml-4 inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                  >
-                    Add Evaluations
-                  </Link>
-                )}
               </div>
-            </div>
+            ) : (
+              <div className="mx-6 mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <InformationCircleIcon className="h-5 w-5 text-blue-600" />
+                    <p className="text-sm text-blue-800">
+                      {isOwner
+                        ? "This document has no evaluations."
+                        : "This document doesn't have any evaluations, but you can still read the content below."}
+                    </p>
+                  </div>
+                  {isOwner && (
+                    <Link
+                      href={`/docs/${document.id}`}
+                      className="ml-4 inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    >
+                      Add Evaluations
+                    </Link>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Failed job warnings (only visible to owner) */}
+            {isOwner && failedJobs.length > 0 && (
+              <div className="mx-6 mb-4 rounded-lg border border-red-200 bg-red-50 p-4">
+                <div className="flex items-start gap-2">
+                  <ExclamationTriangleIcon className="h-5 w-5 text-red-600 mt-0.5" />
+                  <div className="flex-1">
+                    <p className="text-sm text-red-800 font-medium mb-2">
+                      {failedJobs.length === 1 
+                        ? "Warning: Evaluation failed"
+                        : `Warning: ${failedJobs.length} evaluations failed`
+                      }
+                    </p>
+                    <div className="space-y-1">
+                      {failedJobs.map((job) => (
+                        <p key={job.id} className="text-sm text-red-700">
+                          • Evaluation "{job.agentName}" failed
+                        </p>
+                      ))}
+                    </div>
+                    <Link
+                      href={`/docs/${document.id}`}
+                      className="mt-2 inline-flex items-center text-sm font-medium text-red-800 hover:text-red-900"
+                    >
+                      View details in dashboard →
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            )}
             {/* Document metadata section */}
             <DocumentMetadata document={document} />
 

--- a/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
+++ b/src/components/DocumentWithEvaluations/components/EmptyEvaluationsView.tsx
@@ -19,7 +19,7 @@ interface EmptyEvaluationsViewProps {
   document: Document;
   contentWithMetadataPrepend: string;
   isOwner?: boolean;
-  pendingJobsCount?: number;
+  hasPendingJobs?: boolean;
   failedJobs?: FailedJob[];
 }
 
@@ -27,7 +27,7 @@ export function EmptyEvaluationsView({
   document,
   contentWithMetadataPrepend,
   isOwner = false,
-  pendingJobsCount = 0,
+  hasPendingJobs = false,
   failedJobs = [],
 }: EmptyEvaluationsViewProps) {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -41,12 +41,12 @@ export function EmptyEvaluationsView({
           {/* Main content area */}
           <div ref={contentRef} className="relative max-w-3xl flex-1 p-0">
             {/* Message banner at the top */}
-            {pendingJobsCount > 0 ? (
+            {hasPendingJobs ? (
               <div className="mx-6 mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4">
                 <div className="flex items-center gap-2">
                   <InformationCircleIcon className="h-5 w-5 text-amber-600" />
                   <p className="text-sm text-amber-800">
-                    Processing {pendingJobsCount} evaluation{pendingJobsCount > 1 ? 's' : ''}... This may take a few moments.
+                    Processing evaluations... This may take a few moments.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Implements evaluation status messages for the reader page to improve user experience when evaluations are in different states.

### Features Added
- **Processing message**: Shows amber banner when evaluations are pending/running
- **No evaluations message**: Clear messaging for documents without evaluations  
- **Private failure warnings**: Red warning banners visible only to document owners
- **Public vs private visibility**: Different messages for owners vs general users

### Key Changes
- Modified `DocumentWithEvaluations/index.tsx` to detect pending/failed jobs
- Updated `EmptyEvaluationsView.tsx` with conditional status messaging
- Added proper TypeScript typing for job status data
- Implemented owner-specific failure warnings with dashboard links

### User Experience
- **Public users**: See simple "no evaluations" or "processing" messages
- **Document owners**: Additionally see failure warnings and management links
- **Processing state**: Clear indication when evaluations are being generated
- **Failed evaluations**: Private warnings with actionable links to dashboard

Addresses issue #61 by providing clear feedback about evaluation status instead of confusing "No evaluations" warnings when jobs are actually pending.

🤖 Generated with [Claude Code](https://claude.ai/code)