### PR TITLE
Clean up temporal comments and enforce better code documentation practices

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/export-data/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/export-data/route.ts
@@ -188,12 +188,10 @@ export async function GET(request: NextRequest, context: { params: Promise<{ age
           self_critique: evalVersion.selfCritique,
           comment_count: evalVersion.comments.length,
           comments: evalVersion.comments.map((comment) => ({
-            // New standardized fields
             header: 'header' in comment ? comment.header : null,
             level: 'level' in comment ? comment.level : null,
             source: 'source' in comment ? comment.source : null,
             metadata: 'metadata' in comment ? comment.metadata : null,
-            // Original fields
             description: comment.description,
             importance: comment.importance,
             grade: comment.grade,

--- a/apps/web/src/app/api/documents/[slugOrId]/export/route.ts
+++ b/apps/web/src/app/api/documents/[slugOrId]/export/route.ts
@@ -112,12 +112,10 @@ function documentToYAML(doc: Document): string {
         analysis: review.analysis,
         grade: review.grade,
         comments: review.comments?.map((comment: Comment) => ({
-          // New standardized fields
           header: comment.header,
           level: comment.level,
           source: comment.source,
           metadata: comment.metadata,
-          // Original fields
           description: comment.description,
           importance: comment.importance,
           grade: comment.grade,
@@ -167,12 +165,10 @@ function documentToJSON(doc: Document): Record<string, any> {
         grade: review.grade,
         selfCritique: review.selfCritique,
         comments: review.comments?.map((comment: Comment) => ({
-          // New standardized fields
           header: comment.header,
           level: comment.level,
           source: comment.source,
           metadata: comment.metadata,
-          // Original fields
           description: comment.description,
           importance: comment.importance,
           grade: comment.grade,

--- a/apps/web/src/app/docs/[docId]/evaluations/components/VersionDetails.tsx
+++ b/apps/web/src/app/docs/[docId]/evaluations/components/VersionDetails.tsx
@@ -199,7 +199,6 @@ export function VersionDetails({
                 grade: comment.grade || null,
                 evaluationVersionId: `version-${index}`,
                 highlightId: `highlight-${index}`,
-                // New standardized fields
                 header: comment.header ?? null,
                 level: comment.level ?? null,
                 source: comment.source ?? null,

--- a/apps/web/src/app/monitor/evals/page.tsx
+++ b/apps/web/src/app/monitor/evals/page.tsx
@@ -44,7 +44,6 @@ interface Evaluation {
       description: string;
       importance: number | null;
       grade: number | null;
-      // New standardized fields
       header: string | null;
       level: string | null;
       source: string | null;
@@ -277,7 +276,6 @@ export default function EvaluationsMonitorPage() {
                   grade: comment.grade ?? null,
                   evaluationVersionId: selectedVersion.id,
                   highlightId: comment.id,
-                  // New standardized fields
                   header: comment.header ?? null,
                   level: comment.level ?? null,
                   source: comment.source ?? null,

--- a/apps/web/src/components/AgentDetail/tabs/EvaluationsTab.tsx
+++ b/apps/web/src/components/AgentDetail/tabs/EvaluationsTab.tsx
@@ -251,7 +251,6 @@ export function EvaluationsTab({
                     grade: comment.grade ?? null,
                     evaluationVersionId: selectedEvaluation.evaluationId,
                     highlightId: comment.id,
-                    // New standardized fields
                     header: comment.header ?? null,
                     level: comment.level ?? null,
                     source: comment.source ?? null,

--- a/apps/web/src/components/DocumentWithEvaluations/components/EvaluationView.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/EvaluationView.tsx
@@ -295,7 +295,6 @@ export function EvaluationView({
                               grade: comment.grade ?? null,
                               evaluationVersionId: evaluation.id || '',
                               highlightId: `${evaluation.agentId}-highlight-${index}`,
-                              // New standardized fields
                               header: comment.header ?? null,
                               level: comment.level ?? null,
                               source: comment.source ?? null,

--- a/apps/web/src/components/EvaluationComments.tsx
+++ b/apps/web/src/components/EvaluationComments.tsx
@@ -15,7 +15,6 @@ type DatabaseComment = {
   grade: number | null;
   evaluationVersionId: string;
   highlightId: string;
-  // New standardized fields (optional for backwards compatibility)
   header?: string | null;
   level?: string | null;
   source?: string | null;

--- a/apps/web/src/lib/analysis-plugins/plugins/fact-check/commentGeneration.ts
+++ b/apps/web/src/lib/analysis-plugins/plugins/fact-check/commentGeneration.ts
@@ -29,7 +29,6 @@ export function generateFactCheckComments(
     significance: getSignificance(fact),
     importance: getImportanceScore(fact),
     
-    // New standardized fields
     header: getHeaderText(fact),
     level: getFactLevel(fact),
     source: 'fact-check',

--- a/apps/web/src/lib/analysis-plugins/plugins/forecast/index.ts
+++ b/apps/web/src/lib/analysis-plugins/plugins/forecast/index.ts
@@ -170,7 +170,6 @@ class ExtractedForecast {
       },
       importance: this.commentImportanceScore(),
       
-      // New standardized fields
       header: this.getHeaderText(),
       level: this.getLevel(),
       source: 'forecast',

--- a/apps/web/src/lib/analysis-plugins/plugins/math/index.ts
+++ b/apps/web/src/lib/analysis-plugins/plugins/math/index.ts
@@ -90,7 +90,6 @@ export class HybridMathErrorWrapper {
       },
       importance: this.commentImportanceScore(),
       
-      // New standardized fields
       header: this.verificationResult.conciseCorrection || `Math Error: ${this.expression.originalText}`,
       level: 'error' as const, // HybridMathErrorWrapper only handles errors
       source: 'math',
@@ -249,7 +248,6 @@ export class ExtractedMathExpression {
       },
       importance: this.commentImportanceScore(),
       
-      // New standardized fields
       header: this.expression.conciseCorrection || 
               (this.expression.hasError ? `Math Error: ${this.expression.originalText}` : `Math: ${this.expression.originalText}`),
       level: this.expression.hasError ? 'error' as const : 

--- a/apps/web/src/lib/analysis-plugins/plugins/spelling/index.ts
+++ b/apps/web/src/lib/analysis-plugins/plugins/spelling/index.ts
@@ -271,7 +271,6 @@ export class SpellingAnalyzerJob implements SimpleAnalysisPlugin {
       },
       importance,
       
-      // New standardized fields
       header: error.conciseCorrection || `${error.text} → ${error.correction}`,
       level: 'error' as const, // Spelling/grammar issues are always errors
       source: 'spelling',

--- a/apps/web/src/lib/evaluation/exportXml.ts
+++ b/apps/web/src/lib/evaluation/exportXml.ts
@@ -21,7 +21,6 @@ interface ExportEvaluationData {
       description: string;
       importance?: number | null;
       grade?: number | null;
-      // New standardized fields
       header?: string | null;
       level?: string | null;
       source?: string | null;

--- a/apps/web/src/lib/evaluation/types.ts
+++ b/apps/web/src/lib/evaluation/types.ts
@@ -14,7 +14,6 @@ export interface EvaluationDisplayData {
     grade: number | null;
     evaluationVersionId: string;
     highlightId: string;
-    // New standardized fields (optional for backwards compatibility)
     header?: string | null;
     level?: string | null;
     source?: string | null;
@@ -73,7 +72,6 @@ export interface EvaluationContentProps {
     grade: number | null;
     evaluationVersionId: string;
     highlightId: string;
-    // New standardized fields (optional for backwards compatibility)
     header?: string | null;
     level?: string | null;
     source?: string | null;


### PR DESCRIPTION
### **User description**
## Summary

This PR eliminates temporal comments that create confusion and maintenance debt throughout the codebase. Comments like `// New standardized fields` become meaningless after merge and violate clean code principles.

## Problem Statement

Temporal comments create several issues:
- **Confusion after 6 months**: What does "new" mean?  
- **Maintenance debt**: Requires manual cleanup
- **Violates clean code**: Comments should explain "why", not "when"
- **Code review noise**: Distracts from actual functionality

## Solution

✅ **Systematic removal** of all temporal language from 13 files  
✅ **Code Comments Policy** already established in CLAUDE.md  
✅ **pr-review-engineer agent** updated to catch future violations  
✅ **Zero functional changes** - identical runtime behavior  

## Files Cleaned Up

### API Routes (2 files)
- `apps/web/src/app/api/agents/[agentId]/export-data/route.ts`
- `apps/web/src/app/api/documents/[slugOrId]/export/route.ts`

### Analysis Plugins (4 files)  
- `apps/web/src/lib/analysis-plugins/plugins/spelling/index.ts`
- `apps/web/src/lib/analysis-plugins/plugins/math/index.ts`
- `apps/web/src/lib/analysis-plugins/plugins/forecast/index.ts`
- `apps/web/src/lib/analysis-plugins/plugins/fact-check/commentGeneration.ts`

### UI Components (4 files)
- `apps/web/src/components/DocumentWithEvaluations/components/EvaluationView.tsx`
- `apps/web/src/components/AgentDetail/tabs/EvaluationsTab.tsx`
- `apps/web/src/app/monitor/evals/page.tsx`
- `apps/web/src/app/docs/[docId]/evaluations/components/VersionDetails.tsx`

### Type Definitions (3 files)
- `apps/web/src/lib/evaluation/types.ts`
- `apps/web/src/lib/evaluation/exportXml.ts`
- `apps/web/src/components/EvaluationComments.tsx`

## Before & After Examples

### ❌ Before (Temporal - Bad)
```typescript
// New standardized fields
header?: string | null;
level?: string | null;
source?: string | null;
metadata?: Record<string, any> | null;
// Original fields  
description: string;
```

### ✅ After (Clean - Good)
```typescript
header?: string | null;
level?: string | null;
source?: string | null;
metadata?: Record<string, any> | null;
description: string;
```

## Future Prevention

The **pr-review-engineer agent** now has mandatory temporal comment detection:
- Scans all modified files for temporal language
- Flags comments with "new", "old", "added", "updated", "recent", "legacy"
- Suggests removal or replacement with functional descriptions
- **This is now a critical quality check** for all PRs

## Impact Assessment

- ✅ **Zero functional changes** - identical runtime behavior
- ✅ **Improved maintainability** - removes confusing temporal references  
- ✅ **Better code quality** - follows established clean code principles
- ✅ **Systematic prevention** - automated detection prevents regression
- ✅ **Developer experience** - cleaner, more readable codebase

This PR completes the implementation of our Code Comments Policy and ensures the codebase follows professional documentation standards.

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Other


___

### **Description**
- Remove temporal comments from 13 files across codebase

- Clean up "New standardized fields" and "Original fields" comments

- Improve code maintainability by eliminating confusing temporal references

- Zero functional changes, only comment cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Temporal Comments"] --> B["Comment Cleanup"]
  B --> C["API Routes"]
  B --> D["Analysis Plugins"]
  B --> E["UI Components"]
  B --> F["Type Definitions"]
  C --> G["Cleaner Codebase"]
  D --> G
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Remove temporal comments from agent export API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-261cb7573df7e0705e46f25660b36e82e7baf8a540dcf043cf596f1fb6e247f0">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>Clean up temporal comments in document export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-9fcca1abb831733cf817779a73b576d5bb7efb4ff988a1a12c8e0b1460fcc639">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commentGeneration.ts</strong><dd><code>Remove temporal comment from fact-check plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-c83b5a8b52b121b7753e5200d537de4c3c793c621524c08004e8023e8a55c13c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Clean up temporal comment in forecast plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-baddd92d1f1117495402d282590c03c6268cc8a65891ffda39f0f56a34ed97e1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Remove temporal comments from math plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-09b284772461f18ea6cd66374a7645727ecaac317ce39641c37747fec61ea38b">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Clean up temporal comment in spelling plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-25502d3aa80d240d03609d6154a29bbfd8e32867144c6ee42c5ced7f476fa82c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exportXml.ts</strong><dd><code>Remove temporal comment from XML export types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-e9fb88fd864ea989579b792200dbe4893e239063a32f9960418a5cbf62b08839">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Clean up temporal comments in evaluation types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-59a9629e2eb15624df12756824046cacf3b4a94c7acccb371cc3b2467fc9c07b">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>VersionDetails.tsx</strong><dd><code>Remove temporal comment from version details component</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-23f87fb71bf517bf9fbcce266278eaa4aac944ca01dcb565682f8c4044c2e185">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Clean up temporal comments in evaluations monitor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-5d2f94d64b35517fd0bd9cbc291801a3ddfbd1537034fc376b3e3079fee5e23b">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluationsTab.tsx</strong><dd><code>Remove temporal comment from evaluations tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-b9e0c05b84d00d6a83057275997aae332d5a85a0658552b3b41f8b20ce7651c3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluationView.tsx</strong><dd><code>Clean up temporal comment in evaluation view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-ffa3ef7d48625924cf4ae658528865744c38572b9265af1abb9ce618838751f3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluationComments.tsx</strong><dd><code>Remove temporal comment from evaluation comments component</code></dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/125/files#diff-e2a824ec62a46c4d407687eeaed924e4cc1885753c6c03e384c38f40f03cab14">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

