### PR TITLE
Fix: Shell script permissions and Claude settings sync for Git worktrees

### DIFF
--- a/dev/scripts/fix-permissions.sh
+++ b/dev/scripts/fix-permissions.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# fix-permissions.sh - Manually fix all script permissions
+#
+# This script can be run manually to fix permissions if needed.
+# However, permissions should be automatically fixed by Git hooks.
+#
+# Usage: ./dev/scripts/fix-permissions.sh
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Fixing script permissions...${NC}"
+
+# Fix shell scripts
+find dev/scripts/ -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
+echo "  ✓ Fixed shell script permissions"
+
+# Fix Python scripts
+find dev/scripts/ -name "*.py" -exec chmod +x {} \; 2>/dev/null || true
+echo "  ✓ Fixed Python script permissions"
+
+# Fix other common executable files
+find . -name "*.js" -path "*/bin/*" -exec chmod +x {} \; 2>/dev/null || true
+find . -name "gradlew" -exec chmod +x {} \; 2>/dev/null || true
+echo "  ✓ Fixed other executable files"
+
+echo -e "${GREEN}✅ All permissions fixed!${NC}"

--- a/dev/scripts/fix-script-permissions.sh
+++ b/dev/scripts/fix-script-permissions.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# fix-permissions.sh - Manually fix all script permissions
+# fix-script-permissions.sh - Fix executable permissions for shell scripts
 #
-# This script can be run manually to fix permissions if needed.
-# However, permissions should be automatically fixed by Git hooks.
+# This script fixes Unix file permissions (chmod +x) for shell scripts.
+# It does NOT affect Claude Code permissions (those are in .claude/settings.local.json).
 #
-# Usage: ./dev/scripts/fix-permissions.sh
+# Usage: ./dev/scripts/fix-script-permissions.sh
 
 set -e
 

--- a/dev/scripts/setup-git-hooks.sh
+++ b/dev/scripts/setup-git-hooks.sh
@@ -54,8 +54,8 @@ CHECKOUT_TYPE=$3
 if [ "$CHECKOUT_TYPE" = "1" ]; then
     echo "🔧 Running post-checkout hooks..."
     
-    # Source the fix-permissions script if available
-    FIX_SCRIPT="$(git rev-parse --show-toplevel)/dev/scripts/fix-permissions.sh"
+    # Source the fix-script-permissions script if available
+    FIX_SCRIPT="$(git rev-parse --show-toplevel)/dev/scripts/fix-script-permissions.sh"
     if [ -f "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; then
         "$FIX_SCRIPT" >/dev/null 2>&1 || true
     else
@@ -91,8 +91,8 @@ create_post_merge_hook() {
 
 echo "🔧 Running post-merge hooks..."
 
-# Source the fix-permissions script if available
-FIX_SCRIPT="$(git rev-parse --show-toplevel)/dev/scripts/fix-permissions.sh"
+# Source the fix-script-permissions script if available
+FIX_SCRIPT="$(git rev-parse --show-toplevel)/dev/scripts/fix-script-permissions.sh"
 if [ -f "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; then
     "$FIX_SCRIPT" >/dev/null 2>&1 || true
 else
@@ -145,8 +145,8 @@ main() {
     echo "  • post-merge - runs after git pull/merge"
     echo ""
     echo "You can also manually run:"
-    echo "  • ./dev/scripts/sync-claude-permissions.sh - sync Claude settings"
-    echo "  • chmod +x dev/scripts/*.sh - fix script permissions"
+    echo "  • ./dev/scripts/sync-claude-permissions.sh - sync Claude Code settings"
+    echo "  • ./dev/scripts/fix-script-permissions.sh - fix shell script execute permissions"
 }
 
 # Check if we're in a git repository

--- a/dev/scripts/setup-git-hooks.sh
+++ b/dev/scripts/setup-git-hooks.sh
@@ -20,25 +20,63 @@ create_post_checkout_hook() {
     
     cat > "$HOOK_FILE" << 'EOF'
 #!/bin/bash
-# post-checkout hook - Sync Claude permissions when switching branches
+# post-checkout hook - Fix permissions and sync Claude settings when switching branches
 
 # Get the checkout type (1 = branch checkout, 0 = file checkout)
 CHECKOUT_TYPE=$3
 
 # Only run for branch checkouts
 if [ "$CHECKOUT_TYPE" = "1" ]; then
-    # Find sync script
-    SYNC_SCRIPT="$(git rev-parse --show-toplevel)/dev/scripts/sync-claude-permissions.sh"
+    echo "🔧 Running post-checkout hooks..."
     
-    if [ -f "$SYNC_SCRIPT" ]; then
-        echo "Syncing Claude permissions..."
+    # Fix script permissions
+    echo "  → Fixing script permissions..."
+    find dev/scripts/ -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
+    find dev/scripts/ -name "*.py" -exec chmod +x {} \; 2>/dev/null || true
+    
+    # Fix other common executable files
+    find . -name "*.js" -path "*/bin/*" -exec chmod +x {} \; 2>/dev/null || true
+    find . -name "gradlew" -exec chmod +x {} \; 2>/dev/null || true
+    
+    # Sync Claude permissions
+    SYNC_SCRIPT="$(git rev-parse --show-toplevel)/dev/scripts/sync-claude-permissions.sh"
+    if [ -f "$SYNC_SCRIPT" ] && [ -x "$SYNC_SCRIPT" ]; then
+        echo "  → Syncing Claude permissions..."
         "$SYNC_SCRIPT" >/dev/null 2>&1 || true
     fi
+    
+    echo "✅ Post-checkout hooks completed!"
 fi
 EOF
     
     chmod +x "$HOOK_FILE"
     echo -e "${GREEN}✓${NC} Created post-checkout hook in: $1"
+}
+
+# Create post-merge hook
+create_post_merge_hook() {
+    local HOOK_FILE="$1/.git/hooks/post-merge"
+    
+    cat > "$HOOK_FILE" << 'EOF'
+#!/bin/bash
+# post-merge hook - Fix permissions after git pull/merge
+
+echo "🔧 Running post-merge hooks..."
+
+# Fix script permissions
+echo "  → Fixing script permissions..."
+find dev/scripts/ -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
+find dev/scripts/ -name "*.py" -exec chmod +x {} \; 2>/dev/null || true
+
+# Fix other common executable files
+find . -name "*.js" -path "*/bin/*" -exec chmod +x {} \; 2>/dev/null || true
+find . -name "gradlew" -exec chmod +x {} \; 2>/dev/null || true
+
+echo "✅ Post-merge hooks completed!"
+EOF
+    
+    chmod +x "$HOOK_FILE"
+    echo -e "${GREEN}✓${NC} Created post-merge hook in: $1"
 }
 
 # Main setup
@@ -49,6 +87,7 @@ main() {
     # Install in main repo
     if [ -d ".git" ]; then
         create_post_checkout_hook "."
+        create_post_merge_hook "."
     fi
     
     # Install in all worktrees
@@ -56,6 +95,7 @@ main() {
         git worktree list --porcelain | grep "^worktree " | cut -d' ' -f2- | while IFS= read -r worktree; do
             if [ -d "$worktree/.git" ] || [ -f "$worktree/.git" ]; then
                 create_post_checkout_hook "$worktree"
+                create_post_merge_hook "$worktree"
             fi
         done
     fi
@@ -63,13 +103,18 @@ main() {
     echo ""
     echo -e "${GREEN}Setup complete!${NC}"
     echo ""
-    echo "Claude permissions will now sync automatically when:"
-    echo "  • Creating new branches"
-    echo "  • Switching between branches"
-    echo "  • Checking out commits"
+    echo "Git hooks will now automatically:"
+    echo "  • Fix script permissions when switching branches"
+    echo "  • Fix script permissions after git pull/merge"
+    echo "  • Sync Claude permissions when switching branches"
     echo ""
-    echo "You can also manually sync with:"
-    echo "  ./dev/scripts/sync-claude-permissions.sh"
+    echo "Hooks installed:"
+    echo "  • post-checkout - runs after branch switches"
+    echo "  • post-merge - runs after git pull/merge"
+    echo ""
+    echo "You can also manually run:"
+    echo "  • ./dev/scripts/sync-claude-permissions.sh - sync Claude settings"
+    echo "  • chmod +x dev/scripts/*.sh - fix script permissions"
 }
 
 # Check if we're in a git repository

--- a/dev/scripts/sync-claude-permissions.sh
+++ b/dev/scripts/sync-claude-permissions.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# sync-claude-permissions.sh - Sync Claude permissions across worktrees and branches
+# sync-claude-permissions.sh - Sync Claude Code settings across worktrees
 #
-# This script helps maintain consistent Claude Code permissions when:
-# 1. Creating new branches in worktrees
-# 2. Switching between branches
-# 3. Updating permissions across all worktrees
+# This script syncs Claude Code's allowed/denied commands (.claude/settings.local.json)
+# from the main repository to worktrees. This is NOT about Unix file permissions!
+#
+# What this script does:
+# - Copies .claude/settings.local.json from main repo to worktrees
+# - Ensures all worktrees have the same Claude Code command permissions
 #
 # Usage:
 #   ./dev/scripts/sync-claude-permissions.sh               # Sync to current directory
@@ -28,8 +30,12 @@ find_main_repo() {
         if [ -f "$current/.git" ]; then
             # This is a worktree, get the main repo
             local gitdir=$(cat "$current/.git" | grep "gitdir:" | cut -d' ' -f2)
+            # Convert relative path to absolute if needed
+            if [[ "$gitdir" != /* ]]; then
+                gitdir="$current/$gitdir"
+            fi
             # Navigate from .git/worktrees/branch to main repo
-            echo "$(cd "$current/$(dirname "$gitdir")/../.." && pwd)"
+            echo "$(cd "$(dirname "$gitdir")/../.." && pwd)"
             return
         elif [ -d "$current/.git" ]; then
             # This is the main repo

--- a/dev/scripts/worktree-manager.sh
+++ b/dev/scripts/worktree-manager.sh
@@ -248,12 +248,12 @@ EOF
     echo "$WORKTREE_PATH" > "$WORKTREE_PATH/.claude_workspace"
     echo "  ✓ Created Claude workspace file"
     
-    # Fix script permissions
-    echo -e "${YELLOW}Fixing script permissions...${NC}"
+    # Fix executable permissions for shell scripts
+    echo -e "${YELLOW}Fixing shell script permissions...${NC}"
     cd "$WORKTREE_PATH"
     find dev/scripts/ -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
     find dev/scripts/ -name "*.py" -exec chmod +x {} \; 2>/dev/null || true
-    echo "  ✓ Script permissions fixed"
+    echo "  ✓ Shell script permissions fixed"
     
     # Install Git hooks in worktree
     echo -e "${YELLOW}Installing Git hooks...${NC}"

--- a/dev/scripts/worktree-manager.sh
+++ b/dev/scripts/worktree-manager.sh
@@ -248,8 +248,36 @@ EOF
     echo "$WORKTREE_PATH" > "$WORKTREE_PATH/.claude_workspace"
     echo "  ✓ Created Claude workspace file"
     
-    # Install dependencies
+    # Fix script permissions
+    echo -e "${YELLOW}Fixing script permissions...${NC}"
     cd "$WORKTREE_PATH"
+    find dev/scripts/ -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
+    find dev/scripts/ -name "*.py" -exec chmod +x {} \; 2>/dev/null || true
+    echo "  ✓ Script permissions fixed"
+    
+    # Install Git hooks in worktree
+    echo -e "${YELLOW}Installing Git hooks...${NC}"
+    # Worktrees share hooks with main repo, but we'll create symlinks for clarity
+    MAIN_HOOKS_DIR="$GIT_ROOT/.git/hooks"
+    WORKTREE_HOOKS_DIR="$GIT_ROOT/.git/worktrees/$BRANCH/hooks"
+    
+    # Create hooks directory for worktree
+    mkdir -p "$WORKTREE_HOOKS_DIR"
+    
+    # Copy hooks from main repo if they exist
+    if [ -f "$MAIN_HOOKS_DIR/post-checkout" ]; then
+        cp "$MAIN_HOOKS_DIR/post-checkout" "$WORKTREE_HOOKS_DIR/post-checkout"
+        chmod +x "$WORKTREE_HOOKS_DIR/post-checkout"
+        echo "  ✓ Installed post-checkout hook"
+    fi
+    
+    if [ -f "$MAIN_HOOKS_DIR/post-merge" ]; then
+        cp "$MAIN_HOOKS_DIR/post-merge" "$WORKTREE_HOOKS_DIR/post-merge"
+        chmod +x "$WORKTREE_HOOKS_DIR/post-merge"
+        echo "  ✓ Installed post-merge hook"
+    fi
+    
+    # Install dependencies
     echo ""
     echo -e "${YELLOW}Installing dependencies...${NC}"
     pnpm install --silent


### PR DESCRIPTION
## Summary
This PR fixes two separate permission-related issues with Git worktrees:

1. **Shell script executable permissions** - Scripts losing their `chmod +x` permission
2. **Claude Code settings sync** - `.claude/settings.local.json` not syncing properly

## The Problems

### Problem 1: Shell Script Permissions
Git only tracks the executable bit, not full file permissions. When files are checked out in worktrees, Git recreates them using the system's umask, which can strip executable permissions. This was causing scripts to lose their executable permissions every time a new worktree was created or branches were switched.

### Problem 2: Claude Settings Sync
The `sync-claude-permissions.sh` script had a bug where it couldn't properly find the main repository from worktrees, causing the sync to fail. This meant worktrees weren't getting the latest Claude Code allowed/denied commands.

## The Solution

### For Shell Script Permissions:
1. **Git Hooks (Automatic)**
   - **post-checkout hook**: Automatically fixes permissions after branch switches
   - **post-merge hook**: Automatically fixes permissions after git pull/merge

2. **Worktree Manager Enhancement**
   - Updated `worktree-manager.sh` to fix permissions when creating new worktrees
   - Automatically installs Git hooks in new worktrees

3. **Manual Fallback**
   - Created `fix-script-permissions.sh` script for manual permission repairs

### For Claude Settings:
- Fixed path resolution bug in `sync-claude-permissions.sh`
- Added clearer documentation about what the script does
- Now properly syncs `.claude/settings.local.json` from main repo to worktrees

## Files Changed
- `dev/scripts/fix-permissions.sh` → `dev/scripts/fix-script-permissions.sh` - Renamed for clarity
- `dev/scripts/worktree-manager.sh` - Enhanced to fix permissions and install hooks
- `dev/scripts/setup-git-hooks.sh` - Updated to create both post-checkout and post-merge hooks
- `dev/scripts/sync-claude-permissions.sh` - Fixed path resolution bug and clarified documentation

## Testing
- Shell script permission fixes: ✅ Tested and working
- Claude settings sync: ✅ Fixed and tested in worktree
- Git hooks: ✅ Working correctly

## Impact
- No breaking changes
- Scripts will maintain executable permissions across all Git operations
- Claude Code settings will sync properly across worktrees
- Clearer naming prevents confusion between the two types of permissions

🤖 Generated with [Claude Code](https://claude.ai/code)