### PR TITLE
Fix missing database migrations for comment standardization fields

### DIFF
--- a/internal-packages/db/prisma/migrations/20250802000000_add_comment_standardization_fields/migration.sql
+++ b/internal-packages/db/prisma/migrations/20250802000000_add_comment_standardization_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "EvaluationComment" ADD COLUMN     "header" TEXT,
+ADD COLUMN     "level" TEXT,
+ADD COLUMN     "metadata" JSONB,
+ADD COLUMN     "source" TEXT;

--- a/internal-packages/db/prisma/migrations/20250802005018_remove_task_price_default/migration.sql
+++ b/internal-packages/db/prisma/migrations/20250802005018_remove_task_price_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Task" ALTER COLUMN "priceInDollars" DROP DEFAULT;


### PR DESCRIPTION
## Summary
This PR adds the missing database migrations that were causing production errors after merging PR #122. The schema was updated but migrations were not created, causing the error: `The column EvaluationComment.header does not exist in the current database.`

## Changes
1. **Add migration for comment standardization fields** - Creates the missing `header`, `level`, `source`, and `metadata` columns on the `EvaluationComment` table
2. **Fix database drift** - Removes default value from `Task.priceInDollars` column to align with current schema

## Root Cause
- PR #122 added new fields to `schema.prisma` but didn't include migration files
- The changes were likely applied to dev databases using `prisma db push` instead of migrations
- This caused production to be out of sync when the code was deployed

## Testing
- ✅ Created migrations using Prisma
- ✅ Verified no database drift exists (`prisma migrate status` shows "Database schema is up to date\!")
- ✅ Tested that empty migration is generated when checking for additional changes
- ✅ Database backup created before making changes

## Deployment Instructions
These migrations need to be deployed to production **before** deploying the application code that uses the new fields.

🤖 Generated with [Claude Code](https://claude.ai/code)