### PR TITLE
Fix Docker production deployment by skipping env validation

### DIFF
--- a/apps/web/src/lib/build-validation.ts
+++ b/apps/web/src/lib/build-validation.ts
@@ -23,6 +23,13 @@ export function validateBuildEnvironment() {
   const missing: string[] = [];
   const warnings: string[] = [];
 
+  // Docker builds use dummy values during build time
+  // Real values are injected at runtime in Kubernetes
+  if (process.env.DOCKER_BUILD) {
+    console.log('📦 Skipping environment validation for Docker build');
+    return;
+  }
+
   // Check required variables
   for (const envVar of REQUIRED_ENV_VARS) {
     if (!process.env[envVar]) {
@@ -62,6 +69,7 @@ export function validateBuildEnvironment() {
 }
 
 // Run validation immediately when this module is imported
-if (process.env.NODE_ENV !== 'test') {
+// Skip validation during Docker builds since env vars are injected at runtime
+if (process.env.NODE_ENV !== 'test' && !process.env.DOCKER_BUILD) {
   validateBuildEnvironment();
 }


### PR DESCRIPTION
- Skip environment validation when DOCKER_BUILD=true
- Add early return in validateBuildEnvironment() for Docker builds
- Docker builds use dummy values during build time, real values injected at runtime
- Fixes container startup failures in Kubernetes where env vars are injected after build

This allows containers to start successfully while preserving validation for:
- Local development (catches missing .env.local)
- Vercel builds (catches missing dashboard config)
- Other environments where env vars are available at build time

🤖 Generated with [Claude Code](https://claude.ai/code)