### PR TITLE
Fix: Restore highlight saving and validation after PR #161 regression

### DIFF
--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -418,7 +418,8 @@ export class JobRepository implements JobRepositoryInterface {
             id: v.id,
             title: v.title,
             content: v.content,
-            fullContent: v.fullContent,
+            // Compute fullContent: prepend + content if prepend exists, otherwise just content
+            fullContent: v.markdownPrepend ? v.markdownPrepend + v.content : v.content,
             authors: v.authors,
             urls: v.urls,
             platforms: v.platforms,

--- a/internal-packages/jobs/src/core/JobOrchestrator.ts
+++ b/internal-packages/jobs/src/core/JobOrchestrator.ts
@@ -297,7 +297,9 @@ export class JobOrchestrator implements JobOrchestratorInterface {
     // Save highlights to database
     const highlights = evaluationOutputs.highlights || [];
     if (highlights.length > 0) {
-      await this.saveHighlights(highlights, evaluationVersion.id, documentVersion.content);
+      // Use fullContent (which includes markdownPrepend) for validation
+      // since highlights were generated based on the full content
+      await this.saveHighlights(highlights, evaluationVersion.id, documentVersion.fullContent);
       this.logger.info(`Saved ${highlights.length} highlights for evaluation`, {
         evaluationId: job.evaluation.id,
         highlightCount: highlights.length,

--- a/internal-packages/jobs/src/core/JobOrchestrator.ts
+++ b/internal-packages/jobs/src/core/JobOrchestrator.ts
@@ -309,6 +309,9 @@ export class JobOrchestrator implements JobOrchestratorInterface {
 
   /**
    * Save highlights with validation
+   * 
+   * Note: Highlights are linked to evaluations through comments (not directly).
+   * This ensures every highlight has an associated comment for context.
    */
   private async saveHighlights(highlights: any[], evaluationVersionId: string, fullContent: string) {
     if (!highlights || highlights.length === 0) {
@@ -342,13 +345,20 @@ export class JobOrchestrator implements JobOrchestratorInterface {
         }
       }
 
+      // Only create highlight if we have highlight data
+      if (!comment.highlight) {
+        // Skip this comment if no highlight data
+        this.logger.warn(`Skipping comment without highlight data: ${comment.description}`);
+        continue;
+      }
+
       // Create highlight with validation status
       const createdHighlight = await prisma.evaluationHighlight.create({
         data: {
-          startOffset: comment.highlight!.startOffset,
-          endOffset: comment.highlight!.endOffset,
-          quotedText: comment.highlight!.quotedText,
-          prefix: comment.highlight!.prefix || null,
+          startOffset: comment.highlight.startOffset,
+          endOffset: comment.highlight.endOffset,
+          quotedText: comment.highlight.quotedText,
+          prefix: comment.highlight.prefix || null,
           isValid,
           error,
         },


### PR DESCRIPTION
### **User description**
## Summary
Fixes critical regression from PR #161 where evaluation comments were not being saved to the database, and when they were saved, highlights were marked as invalid due to offset mismatches.

## Problem
PR #161 (job extraction refactor) introduced two bugs:
1. **Comments not saved**: The `saveHighlights` method was removed, replaced with just a log message
2. **Invalid highlights**: When restored, highlights failed validation because they were validated against raw `content` but generated from `fullContent` (which includes `markdownPrepend`)

## Solution

### 1. Restored the `saveHighlights` method
- Creates `evaluationHighlight` records with validation
- Creates `evaluationComment` records linked to highlights
- Validates that quoted text matches document at specified offsets

### 2. Fixed highlight validation to use fullContent
- Highlights are generated based on the full document content (markdownPrepend + content)
- Validation now uses the same fullContent for offset calculations
- Added computation of fullContent in JobRepository

## Changes
- `internal-packages/jobs/src/core/JobOrchestrator.ts`: Restored highlight saving logic
- `internal-packages/db/src/repositories/JobRepository.ts`: Compute fullContent with markdownPrepend

## Testing
✅ Created test jobs and verified:
- Comments are now saved to database (previously 0 comments saved)
- All highlights marked as **valid** (previously all marked as invalid)
- API returns comments correctly
- Evaluation page displays comments at http://localhost:3001/docs/E77ftiQI2zT80K7K/evals/PBjTP0hnLR5J6AnP

## Before/After
**Before**: Evaluations showed 0 comments despite successful job runs
**After**: Evaluations show all generated comments with valid highlight positions

Fixes regression introduced in #161

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Restore highlight saving functionality removed in PR #161

- Fix highlight validation using fullContent instead of raw content

- Ensure evaluation comments are properly saved to database

- Resolve offset mismatches in highlight text validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Job Orchestrator"] --> B["Generate Highlights"]
  B --> C["Validate Against fullContent"]
  C --> D["Save to Database"]
  D --> E["Create Highlight Records"]
  D --> F["Create Comment Records"]
  G["Job Repository"] --> H["Compute fullContent"]
  H --> I["markdownPrepend + content"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JobOrchestrator.ts</strong><dd><code>Restore highlight saving with proper validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/jobs/src/core/JobOrchestrator.ts

<ul><li>Restored <code>saveHighlights</code> method that was removed in PR #161<br> <li> Added highlight validation against <code>fullContent</code> instead of raw content<br> <li> Creates <code>evaluationHighlight</code> and <code>evaluationComment</code> database records<br> <li> Validates quoted text matches document at specified offsets</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/162/files#diff-24c4f409bf682f963d0abd231fbebf201b929907599d18184bcc763a0480d427">+68/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JobRepository.ts</strong><dd><code>Fix fullContent computation for highlight validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/db/src/repositories/JobRepository.ts

<ul><li>Compute <code>fullContent</code> by concatenating <code>markdownPrepend</code> and <code>content</code><br> <li> Ensures highlight validation uses same content as highlight generation</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/162/files#diff-7a1913f23b425cfabfc7c576ea01a458bfae03be064a416ca2d33a7a426a7493">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

