### PR TITLE
feat: enhance link validator with LessWrong/EA Forum API support

### DIFF
--- a/internal-packages/ai/src/tools/link-validator/link-validator-lesswrong-ea.integration.vtest.ts
+++ b/internal-packages/ai/src/tools/link-validator/link-validator-lesswrong-ea.integration.vtest.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { linkValidator } from "./index";
+
+describe("link-validator LessWrong and EA Forum integration tests", () => {
+  const mockContext = {
+    logger: { 
+      info: vi.fn(), 
+      error: vi.fn(), 
+      debug: vi.fn(), 
+      warn: vi.fn() 
+    }
+  };
+
+  it("should validate LessWrong URLs using GraphQL API", async () => {
+    const input = {
+      text: `
+        Check out these LessWrong posts:
+        - Valid post: https://www.lesswrong.com/posts/AqbWna2S85pFTsHH4/the-intelligent-social-web
+        - Invalid post: https://www.lesswrong.com/posts/FAKEIDNOTEXIST/fake-post
+      `,
+    };
+
+    const result = await linkValidator.execute(input, mockContext);
+
+    expect(result.urls).toHaveLength(2);
+    
+    // Find the validation results
+    const validPost = result.validations.find((v: any) => 
+      v.url.includes("AqbWna2S85pFTsHH4"));
+    const invalidPost = result.validations.find((v: any) => 
+      v.url.includes("FAKEIDNOTEXIST"));
+
+    // Valid post should be accessible
+    expect(validPost?.accessible).toBe(true);
+    expect(validPost?.details?.statusCode).toBe(200);
+    expect(validPost?.validationMethod).toBe("LessWrong GraphQL API");
+    
+    // Invalid post should not be accessible
+    expect(invalidPost?.accessible).toBe(false);
+    expect(invalidPost?.error?.type).toBe("NotFound");
+    expect(invalidPost?.validationMethod).toBe("LessWrong GraphQL API");
+  }, 30000);
+
+  it("should validate EA Forum URLs using GraphQL API", async () => {
+    const input = {
+      text: `
+        Here are some EA Forum posts:
+        - Valid post: https://forum.effectivealtruism.org/posts/bfdc3MpsYEfDdvgtP/why-i-think-ai-safety-field-building-is-one-of
+        - Invalid post: https://forum.effectivealtruism.org/posts/NOTAREALID123/fake-ea-post
+      `,
+    };
+
+    const result = await linkValidator.execute(input, mockContext);
+
+    expect(result.urls).toHaveLength(2);
+    
+    // Find the validation results
+    const validPost = result.validations.find((v: any) => 
+      v.url.includes("bfdc3MpsYEfDdvgtP"));
+    const invalidPost = result.validations.find((v: any) => 
+      v.url.includes("NOTAREALID123"));
+
+    // Valid post should be accessible
+    expect(validPost?.accessible).toBe(true);
+    expect(validPost?.details?.statusCode).toBe(200);
+    expect(validPost?.validationMethod).toBe("EA Forum GraphQL API");
+    
+    // Invalid post should not be accessible
+    expect(invalidPost?.accessible).toBe(false);
+    expect(invalidPost?.error?.type).toBe("NotFound");
+    expect(invalidPost?.validationMethod).toBe("EA Forum GraphQL API");
+  }, 30000);
+
+  it("should handle mixed URLs correctly", async () => {
+    const input = {
+      text: `
+        Mixed links:
+        - LessWrong: https://www.lesswrong.com/posts/AqbWna2S85pFTsHH4/the-intelligent-social-web
+        - EA Forum: https://forum.effectivealtruism.org/posts/bfdc3MpsYEfDdvgtP/why-i-think
+        - Regular site: https://www.google.com
+        - Broken link: https://definitely-not-a-real-domain-xyz123.com
+      `,
+    };
+
+    const result = await linkValidator.execute(input, mockContext);
+
+    expect(result.urls).toHaveLength(4);
+    
+    // Check that we have a mix of working and broken links
+    const workingLinks = result.validations.filter((v: any) => v.accessible);
+    const brokenLinks = result.validations.filter((v: any) => !v.accessible);
+    
+    // We should have at least 3 working links (LW, EA, Google)
+    expect(workingLinks.length).toBeGreaterThanOrEqual(3);
+    // And 1 broken link
+    expect(brokenLinks.length).toBeGreaterThanOrEqual(1);
+    
+    // Summary should reflect the results
+    expect(result.summary.totalLinks).toBe(4);
+    expect(result.summary.workingLinks).toBeGreaterThanOrEqual(3);
+    expect(result.summary.brokenLinks).toBeGreaterThanOrEqual(1);
+    
+    // Check that methods are tracked
+    expect(result.summary.methodsUsed).toBeDefined();
+    expect(result.summary.methodsUsed["LessWrong GraphQL API"]).toBe(1);
+    expect(result.summary.methodsUsed["EA Forum GraphQL API"]).toBe(1);
+    expect(result.summary.methodsUsed["HTTP Request"]).toBe(2);
+  }, 30000);
+});

--- a/internal-packages/ai/src/tools/link-validator/linkHighlightGenerator.ts
+++ b/internal-packages/ai/src/tools/link-validator/linkHighlightGenerator.ts
@@ -171,23 +171,34 @@ export function generateLinkHighlights(
       let importance: number;
       let description: string;
 
+      // Get validation method info
+      const validationMethod = linkResult.validationMethod || "HTTP Request";
+      const methodNote = validationMethod !== "HTTP Request" ? ` (verified via ${validationMethod})` : "";
+      
       if (linkResult.accessError) {
         // Handle different error types
         switch (linkResult.accessError.type) {
           case "NotFound":
             grade = 0;
             importance = 100;
-            description = `❌ Broken link\n\n[${formatUrlForDisplay(url)}](${url}) - Page not found (HTTP 404)`;
+            description = `❌ Broken link\n\n[${formatUrlForDisplay(url)}](${url}) - Page not found (HTTP 404)${methodNote}`;
             break;
           case "Forbidden":
-            grade = 0;
-            importance = 100;
-            description = `🚫 Access denied\n\n[${formatUrlForDisplay(url)}](${url}) - Access forbidden (HTTP 403)`;
+            // Treat 403 as a warning, not an error (site exists but blocks access)
+            grade = 50;
+            importance = 50;
+            description = `⚠️ Access restricted\n\n[${formatUrlForDisplay(url)}](${url}) - Site exists but blocks automated access (HTTP 403)${methodNote}`;
+            break;
+          case "RateLimited":
+            // Also treat rate limiting as a warning
+            grade = 50;
+            importance = 50;
+            description = `⚠️ Rate limited\n\n[${formatUrlForDisplay(url)}](${url}) - Site exists but temporarily rate limited${methodNote}`;
             break;
           case "Timeout":
             grade = 0;
             importance = 100;
-            description = `⏱️ Link timeout\n\n[${formatUrlForDisplay(url)}](${url}) - Request timed out`;
+            description = `⏱️ Link timeout\n\n[${formatUrlForDisplay(url)}](${url}) - Request timed out${methodNote}`;
             break;
           default:
             grade = 0;
@@ -196,13 +207,14 @@ export function generateLinkHighlights(
               "message" in linkResult.accessError
                 ? linkResult.accessError.message
                 : "Unknown error";
-            description = `❌ Link error\n\n[${formatUrlForDisplay(url)}](${url}) - ${errorMsg}`;
+            description = `❌ Link error\n\n[${formatUrlForDisplay(url)}](${url}) - ${errorMsg}${methodNote}`;
         }
       } else {
         // URL is accessible - simple verification
         grade = 90;
         importance = 10;
-        description = `✅ Link verified\n\n[${formatUrlForDisplay(url)}](${url}) - Server responded successfully (HTTP 200)`;
+        const statusCode = linkResult.linkDetails?.statusCode || 200;
+        description = `✅ Link verified\n\n[${formatUrlForDisplay(url)}](${url}) - Server responded successfully (HTTP ${statusCode})${methodNote}`;
       }
 
       highlights.push({


### PR DESCRIPTION
## Summary
Enhanced the link validator tool to use GraphQL APIs for LessWrong and EA Forum URLs, improving performance and reliability. Also improved error categorization to distinguish between warnings (site exists but blocks access) and errors (site is broken).

## Changes

### 🚀 LessWrong & EA Forum API Support
- Added direct GraphQL API integration for LessWrong and EA Forum posts
- Faster validation compared to generic HTTP requests
- More reliable - avoids rate limiting and bot detection issues
- Uses parameterized queries to prevent GraphQL injection

### 🎯 Improved Error Categorization
- **Errors** (❌): 404 Not Found, Network Errors, Timeouts - link is likely broken
- **Warnings** (⚠️): 403 Forbidden, Rate Limited - site exists but blocks automated access
- **Success** (✅): Link is accessible and working

### 📊 Enhanced Output
- Each validation now shows which method was used:
  - `"LessWrong GraphQL API"` for LessWrong posts
  - `"EA Forum GraphQL API"` for EA Forum posts
  - `"HTTP Request"` for all other URLs
- Added severity field to distinguish warnings from errors
- Summary now includes warning count and methods used

### 💬 Updated Comment Generation
- 403 errors now show as "⚠️ Access restricted - Site exists but blocks automated access"
- Success messages include "(verified via [API name])" when using GraphQL APIs
- Comments reflect appropriate severity level

## Testing
- ✅ All existing tests pass
- ✅ Added new integration tests for LessWrong/EA Forum APIs
- ✅ Added unit tests for validation method tracking
- ✅ TypeScript types updated and checked

## Benefits
1. **Better User Experience**: 403 errors shown as warnings since the site exists
2. **Performance**: LessWrong/EA Forum links validate faster via GraphQL
3. **Transparency**: Users can see which validation method was used
4. **Security**: Parameterized queries prevent GraphQL injection
5. **Accuracy**: Direct API access provides more reliable results

🤖 Generated with [Claude Code](https://claude.ai/code)