### PR TITLE
Fix massive query performance issues in document listings

### DIFF
--- a/apps/web/src/app/docs/[docId]/reader/page.tsx
+++ b/apps/web/src/app/docs/[docId]/reader/page.tsx
@@ -23,7 +23,7 @@ export default async function DocumentPage({
     notFound();
   }
 
-  const document = await DocumentModel.getDocumentWithEvaluations(docId);
+  const document = await DocumentModel.getDocumentForReader(docId);
 
   if (!document) {
     return (

--- a/apps/web/src/models/Document.ts
+++ b/apps/web/src/models/Document.ts
@@ -924,7 +924,13 @@ export class DocumentModel {
           grade: latestEvalVersion?.grade ?? null,
           selfCritique: latestEvalVersion?.selfCritique || undefined,
           versions: [], // Not needed for listings
-          jobs: evaluation.jobs || [],
+          jobs: (evaluation.jobs || []).map((job: any) => ({
+            id: job.id,
+            status: job.status,
+            createdAt: job.createdAt,
+            // Convert Decimal to number to avoid serialization errors
+            priceInDollars: convertPriceToNumber(job.priceInDollars),
+          })),
           isStale,
         };
       }),

--- a/apps/web/src/models/Document.ts
+++ b/apps/web/src/models/Document.ts
@@ -891,22 +891,10 @@ export class DocumentModel {
                 summary: true,
                 analysis: true,
                 selfCritique: true,
-                // Minimal comment data for count only
-                comments: {
+                // Only get comment count for document list - no need for actual comments or highlights
+                _count: {
                   select: {
-                    id: true,
-                    description: true,
-                    importance: true,
-                    grade: true,
-                    highlight: {
-                      select: {
-                        id: true,
-                        startOffset: true,
-                        endOffset: true,
-                        quotedText: true,
-                        isValid: true,
-                      },
-                    },
+                    comments: true,
                   },
                 },
                 documentVersion: {
@@ -974,21 +962,23 @@ export class DocumentModel {
             },
             createdAt: new Date(latestEvalVersion?.createdAt || evaluation.createdAt),
             priceInDollars: 0, // Not needed for listings
-            comments: latestEvalVersion?.comments?.map((comment: any) => ({
-              id: comment.id,
-              description: comment.description,
-              importance: comment.importance || null,
-              grade: comment.grade || null,
+            // Create empty comments array with proper length for count display
+            // The actual comment content is not needed for document listings
+            comments: Array(latestEvalVersion?._count?.comments || 0).fill({
+              id: '',
+              description: '',
+              importance: null,
+              grade: null,
               highlight: {
-                id: comment.highlight.id,
-                startOffset: comment.highlight.startOffset,
-                endOffset: comment.highlight.endOffset,
-                quotedText: comment.highlight.quotedText,
-                isValid: comment.highlight.isValid,
+                id: '',
+                startOffset: 0,
+                endOffset: 0,
+                quotedText: '',
+                isValid: true,
                 prefix: null,
                 error: null,
               },
-            })) || [],
+            }),
             thinking: "",
             summary: latestEvalVersion?.summary || "",
             analysis: latestEvalVersion?.analysis || "",


### PR DESCRIPTION
## Summary
This PR fixes critical performance issues where document listing pages were generating massive database queries with 600+ highlight IDs in IN clauses, causing significant performance degradation.

## Problem
- Document listing pages (`/docs`, `/users/[userId]/documents`) were fetching ALL evaluation comments and highlights
- Documents with many evaluation re-runs (e.g., 46 versions with 1759 total highlights) were causing huge IN clauses
- The reader page was also loading all historical evaluation versions unnecessarily
- Prisma Decimal objects were causing serialization errors when passed to Client Components

## Solution
### 1. Optimized Document Listings
- Created shared `getDocumentListingInclude()` configuration that only fetches comment counts (`_count`)
- Created `formatDocumentForListing()` to format documents with placeholder comment arrays
- Refactored both `getRecentDocumentsWithEvaluations()` and `getUserDocumentsWithEvaluations()` to use the optimized query

### 2. Optimized Reader Page
- Added new `getDocumentForReader()` method that only fetches the latest evaluation version
- Updated reader page to use the optimized method
- Preserves full `getDocumentWithEvaluations()` for other use cases that need version history

### 3. Fixed Decimal Serialization
- Convert Prisma Decimal objects to plain numbers in jobs array
- Prevents "Decimal objects are not supported" errors on listing pages

## Changes
- **Performance**: Dramatically reduced query size - no more 600+ highlight IDs in IN clauses
- **Code Quality**: Eliminated duplication with shared query configuration
- **Bug Fixes**: Fixed Decimal serialization errors
- **Optimization**: Document lists now only fetch what they need (comment counts, not full data)

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint passes (only existing warnings)
- ✅ Document listing pages load efficiently
- ✅ Reader page loads with proper data
- ✅ No more Decimal serialization errors

## Impact
This fix significantly improves performance for:
- Main documents page (`/docs`)
- User documents page (`/users/[userId]/documents`)  
- Document reader page (`/docs/[docId]/reader`)

Especially beneficial for documents with many evaluation versions where the old queries were fetching thousands of unnecessary database records.

🤖 Generated with Claude Code