### PR TITLE
fix: show evaluation header for pending evaluations without versions

### DIFF
--- a/apps/web/src/components/DocumentWithEvaluations/index.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/index.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { useMemo, useState, useEffect } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
-import { HEADER_HEIGHT_PX } from "@/shared/utils/ui/constants";
-import { clearTruncationCache, getTruncationCacheSize } from "@/shared/utils/ui/commentPositioning";
 import { useEvaluationRerun } from "@/shared/hooks/useEvaluationRerun";
+import {
+  clearTruncationCache,
+  getTruncationCacheSize,
+} from "@/shared/utils/ui/commentPositioning";
+import { HEADER_HEIGHT_PX } from "@/shared/utils/ui/constants";
 
 import { EvaluationView } from "./components";
 import { EmptyEvaluationsView } from "./components/EmptyEvaluationsView";
-import type { DocumentWithReviewsProps, EvaluationState } from "./types";
+import type {
+  DocumentWithReviewsProps,
+  EvaluationState,
+} from "./types";
 
 export function DocumentWithEvaluations({
   document,
@@ -16,53 +26,60 @@ export function DocumentWithEvaluations({
   initialSelectedEvalIds,
   showDebugComments = false,
 }: DocumentWithReviewsProps) {
+  // Check if we have any evaluations at all (including pending ones without versions)
   const hasEvaluations = document.reviews && document.reviews.length > 0;
-  
+
   // Use the shared hook for evaluation reruns
   const { handleRerun, runningEvals } = useEvaluationRerun({
     documentId: document.id,
   });
-  
+
   // Check if evaluations have pending or running jobs based on their latest job status
   const hasPendingJobs = useMemo(() => {
-    return document.reviews.some(review => {
+    return document.reviews.some((review) => {
       const mostRecentJob = review.jobs?.[0]; // Jobs are ordered by createdAt desc
-      return mostRecentJob?.status === 'PENDING' || mostRecentJob?.status === 'RUNNING';
+      return (
+        mostRecentJob?.status === "PENDING" ||
+        mostRecentJob?.status === "RUNNING"
+      );
     });
   }, [document.reviews]);
 
   // Get failed jobs from latest evaluation job for owner view
   const failedJobs = useMemo(() => {
     if (!isOwner) return []; // Only calculate for owners
-    
+
     return document.reviews
-      .map(review => {
+      .map((review) => {
         const mostRecentJob = review.jobs?.[0]; // Jobs are ordered by createdAt desc
-        return mostRecentJob?.status === 'FAILED' ? {
-          ...mostRecentJob,
-          agentName: review.agent.name,
-          agentId: review.agentId
-        } : null;
+        return mostRecentJob?.status === "FAILED"
+          ? {
+              ...mostRecentJob,
+              agentName: review.agent.name,
+              agentId: review.agentId,
+            }
+          : null;
       })
       .filter((job): job is NonNullable<typeof job> => job !== null);
   }, [document.reviews, isOwner]);
-  
-  // Initialize evaluation state immediately if we have evaluations
-  const [evaluationState, setEvaluationState] = useState<EvaluationState | null>(
-    hasEvaluations
-      ? {
-          selectedAgentIds: new Set(
-            initialSelectedEvalIds && initialSelectedEvalIds.length > 0
-              ? initialSelectedEvalIds.filter(id => 
-                  document.reviews.some(r => r.agentId === id)
-                )
-              : document.reviews.map((r) => r.agentId)
-          ),
-          hoveredCommentId: null,
-          expandedCommentId: null,
-        }
-      : null
-  );
+
+  // Initialize evaluation state only if we have evaluations
+  const [evaluationState, setEvaluationState] =
+    useState<EvaluationState | null>(
+      hasEvaluations
+        ? {
+            selectedAgentIds: new Set(
+              initialSelectedEvalIds && initialSelectedEvalIds.length > 0
+                ? initialSelectedEvalIds.filter((id) =>
+                    document.reviews.some((r) => r.agentId === id)
+                  )
+                : document.reviews.map((r) => r.agentId)
+            ),
+            hoveredCommentId: null,
+            expandedCommentId: null,
+          }
+        : null
+    );
 
   // Document content already includes prepend from the database query via fullContent computed field
 

--- a/apps/web/src/models/__tests__/Document.vtest.ts
+++ b/apps/web/src/models/__tests__/Document.vtest.ts
@@ -155,17 +155,17 @@ describe('DocumentModel', () => {
       expect(result?.reviews).toHaveLength(1);
       
       // Verify that the query was called with proper where clause for filtering
+      // When includeStale=false and includePending=true (default for getDocumentWithEvaluations)
       expect(prisma.document.findUnique).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 'doc-123' },
           include: expect.objectContaining({
             evaluations: expect.objectContaining({
               where: {
-                versions: {
-                  some: {
-                    isStale: false,
-                  },
-                },
+                OR: [
+                  { versions: { none: {} } }, // Include pending evaluations
+                  { versions: { some: { isStale: false } } }, // Include non-stale evaluations
+                ],
               },
             }),
           }),


### PR DESCRIPTION
### **User description**
## Summary
- Fixed issue where evaluation header wasn't showing when evaluations exist but have no versions yet
- Now properly displays evaluation count and header for pending evaluations

## Changes
- Updated `DocumentQueryBuilder.evaluations()` to properly include evaluations without versions when `includePending: true`
- Fixed conditional rendering in `DocumentWithEvaluations` to show `EvaluationView` when any evaluations exist
- Cleaned up `evaluationState` initialization to be properly conditional based on `hasEvaluations`

## Test plan
1. Create a document with evaluations that have no versions yet (pending state)
2. Navigate to the reader view
3. Verify the evaluation header shows with correct count (e.g., "1 AI Evaluation")
4. Verify the header is interactive and displays properly even without evaluation versions

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed evaluation header display for pending evaluations without versions

- Updated query logic to include evaluations with no versions when `includePending: true`

- Improved conditional rendering to show evaluation view for all evaluations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pending Evaluations"] --> B["Query Builder Update"]
  B --> C["Include No-Version Evaluations"]
  C --> D["Show Evaluation Header"]
  D --> E["Display Count & Interface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Document.ts</strong><dd><code>Enhanced evaluation query logic for pending states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/models/Document.ts

<ul><li>Enhanced query logic to handle <code>includePending</code> and <code>includeStale</code> <br>combinations<br> <li> Added OR condition to include evaluations with no versions (pending <br>state)<br> <li> Updated where clause to properly filter evaluations based on version <br>status</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/208/files#diff-9300505e835d1b71f472c613342e3e22f6306270afa28ef690029b138c392a50">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Code cleanup and formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/DocumentWithEvaluations/index.tsx

<ul><li>Reorganized imports for better structure<br> <li> Improved code formatting and readability<br> <li> Enhanced conditional logic for evaluation state initialization<br> <li> Added better comments explaining evaluation state handling</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/208/files#diff-934481c3fb0f44ade935eb6f1dd6eff1226fa87469c7f34179fb2070063d35d1">+49/-32</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

