### PR TITLE
fix: resolve server-only import error in jobs CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Run script smoke tests
         run: pnpm --filter @roast/web run test:ci src/__tests__/scripts/script-smoke.vtest.ts
 
+      - name: Validate CLI import safety
+        run: pnpm --filter @roast/web run test:ci src/__tests__/scripts/cli-import-validation.vtest.ts
+
       - name: Validate script runtime
         run: pnpm --filter @roast/web run test:scripts
 

--- a/apps/web/src/__tests__/scripts/cli-import-validation.vtest.ts
+++ b/apps/web/src/__tests__/scripts/cli-import-validation.vtest.ts
@@ -1,0 +1,38 @@
+/**
+ * CLI Import Validation Tests
+ * 
+ * These tests validate that CLI components can be imported in Node.js contexts
+ * without server-only module errors. This catches import issues that mocked 
+ * unit tests miss.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('CLI Import Validation', () => {
+  it('should be able to import and instantiate JobRepository (CLI use case)', async () => {
+    // This will fail if JobRepository or its dependencies import server-only modules
+    const { JobRepository } = await import('@roast/db');
+    
+    // Verify the class can be instantiated without throwing server-only errors
+    const repo = new JobRepository();
+    expect(repo).toBeInstanceOf(JobRepository);
+  });
+
+  it('should be able to import CLI-safe database client', async () => {
+    const { cliPrisma } = await import('@roast/db');
+    
+    expect(cliPrisma).toBeDefined();
+    // Verify it has expected Prisma client methods
+    expect(cliPrisma.job).toBeDefined();
+    expect(cliPrisma.evaluation).toBeDefined();
+  });
+
+  it('should be able to import main database exports without server-only errors', async () => {
+    // This tests that the main @roast/db exports work in Node.js contexts
+    const dbModule = await import('@roast/db');
+    
+    expect(dbModule.JobRepository).toBeDefined();
+    expect(dbModule.cliPrisma).toBeDefined();
+    expect(dbModule.generateId).toBeDefined();
+  });
+});

--- a/internal-packages/db/package.json
+++ b/internal-packages/db/package.json
@@ -9,7 +9,8 @@
     ".": {
       "browser": "./browser.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./cli": "./dist/cli.js"
   },
   "scripts": {
     "build": "tsc --build",

--- a/internal-packages/db/src/cli-client.ts
+++ b/internal-packages/db/src/cli-client.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from "../generated";
+
+// Extended client type for CLI/server usage (without server-only restriction)
+function createExtendedClient() {
+  const client = new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "error", "warn"]
+        : ["error"],
+  });
+
+  return client.$extends({
+    result: {
+      documentVersion: {
+        // Computed field that combines markdownPrepend + content
+        fullContent: {
+          needs: {
+            content: true,
+            markdownPrepend: true,
+          },
+          compute(documentVersion) {
+            // Use prepend + content if prepend exists, otherwise just content
+            if (documentVersion.markdownPrepend) {
+              return documentVersion.markdownPrepend + documentVersion.content;
+            }
+
+            return documentVersion.content;
+          },
+        },
+      },
+    },
+  });
+}
+
+// Simple singleton pattern for Prisma client
+const globalForPrisma = globalThis as unknown as {
+  prisma: ReturnType<typeof createExtendedClient> | undefined;
+};
+
+export const prisma = globalForPrisma.prisma ?? createExtendedClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+// Export Prisma both as type and value, PrismaClient as type only
+export { Prisma, type PrismaClient } from "../generated";

--- a/internal-packages/db/src/cli.ts
+++ b/internal-packages/db/src/cli.ts
@@ -1,0 +1,19 @@
+// CLI-safe exports - safe to use in CLI scripts and server contexts
+export { prisma as cliPrisma } from './cli-client';
+
+// CLI-safe repositories (only JobRepository for now, others use server-only client)
+export { 
+  JobRepository,
+  type JobEntity,
+  type JobWithRelations,
+  type CreateJobData,
+  type UpdateJobStatusData,
+  type JobRepositoryInterface
+} from './repositories/JobRepository';
+
+// Types and utilities (always safe)
+export * from './types';
+export { generateId } from './utils/generateId';
+
+// Re-export Prisma types (type-only imports are safe)
+export { Prisma, type PrismaClient } from './cli-client';

--- a/internal-packages/db/src/index.ts
+++ b/internal-packages/db/src/index.ts
@@ -2,6 +2,9 @@
 export { prisma } from './client';
 export { ensureDbConnected, withDb } from './ensure-connected';
 
+// CLI-safe exports - Prisma client for CLI scripts and server contexts
+export { prisma as cliPrisma } from './cli-client';
+
 // Re-export Prisma types from client (which properly exports from generated)
 export { Prisma, type PrismaClient } from './client';
 

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -6,10 +6,10 @@
  * Returns domain entities with minimal dependencies.
  */
 
-import { prisma as defaultPrisma } from '../client';
+import { prisma as defaultPrisma } from '../cli-client';
 import { JobStatus } from '../types';
 import type { Job } from '../types';
-import type { PrismaClient } from '../client';
+import type { PrismaClient } from '../cli-client';
 import { generateId } from '../utils/generateId';
 
 // Domain types defined in this package to avoid circular dependencies

--- a/internal-packages/jobs/src/cli/process-adaptive.ts
+++ b/internal-packages/jobs/src/cli/process-adaptive.ts
@@ -11,10 +11,10 @@ import {
   spawn,
 } from "child_process";
 
-import { prisma, JobStatus } from "@roast/db";
+import { cliPrisma as prisma, JobStatus } from "@roast/db/cli";
 import { getAgentTimeout, formatTimeout } from "../config/agentTimeouts";
 import { config } from '@roast/domain';
-import { JobRepository } from '@roast/db';
+import { JobRepository } from '@roast/db/cli';
 import { JobService } from '../core/JobService';
 import { logger } from '../utils/logger';
 

--- a/internal-packages/jobs/src/cli/process-job.ts
+++ b/internal-packages/jobs/src/cli/process-job.ts
@@ -6,7 +6,7 @@ import { findWorkspaceRoot, loadWebAppEnvironment } from '../utils/workspace';
 const workspaceRoot = findWorkspaceRoot(__dirname);
 loadWebAppEnvironment(workspaceRoot);
 
-import { JobRepository } from '@roast/db';
+import { JobRepository } from '@roast/db/cli';
 import { JobService } from '../core/JobService';
 import { JobOrchestrator } from '../core/JobOrchestrator';
 import { initializeAI } from '@roast/ai';

--- a/internal-packages/jobs/src/core/JobOrchestrator.ts
+++ b/internal-packages/jobs/src/core/JobOrchestrator.ts
@@ -6,8 +6,8 @@
  * Now uses @roast/ai workflows directly instead of dependency injection.
  */
 
-import type { JobWithRelations, JobEntity } from '@roast/db';
-import { prisma } from '@roast/db';
+import type { JobWithRelations, JobEntity } from '@roast/db/cli';
+import { cliPrisma as prisma } from '@roast/db/cli';
 import type { JobService } from './JobService';
 import type { Logger, JobProcessingResult, Document } from '../types';
 import { 

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -12,8 +12,8 @@ import type {
   JobWithRelations, 
   CreateJobData, 
   UpdateJobStatusData 
-} from '@roast/db';
-import { JobStatus } from '@roast/db';
+} from '@roast/db/cli';
+import { JobStatus } from '@roast/db/cli';
 import type { Logger, CompletionData } from '../types';
 
 export interface JobServiceInterface {

--- a/internal-packages/jobs/src/core/__tests__/JobOrchestrator.vtest.ts
+++ b/internal-packages/jobs/src/core/__tests__/JobOrchestrator.vtest.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JobOrchestrator } from '../JobOrchestrator';
 import { JobService } from '../JobService';
 import { analyzeDocument } from '@roast/ai';
-import { prisma, JobStatus } from '@roast/db';
+import { cliPrisma as prisma, JobStatus } from '@roast/db/cli';
 import { fetchJobCostWithRetry } from '@roast/ai';
 import type { Logger } from '../../types';
 
@@ -19,8 +19,8 @@ vi.mock('@roast/ai', () => ({
   fetchJobCostWithRetry: vi.fn(),
 }));
 
-vi.mock('@roast/db', () => ({
-  prisma: {
+vi.mock('@roast/db/cli', () => ({
+  cliPrisma: {
     evaluationVersion: {
       findFirst: vi.fn(),
       create: vi.fn(),


### PR DESCRIPTION
## Summary
- Fixes server-only module error preventing jobs CLI commands from running
- Creates CLI-safe database client without server-only restrictions
- Updates all jobs packages to use CLI-safe imports
- Adds validation tests to prevent future CLI import issues

## Problem
After recent PR merges, the database client added `server-only` imports that prevented CLI scripts from running, causing this error:
```
Error: This module cannot be imported from a Client Component module. It should only be used from a Server Component.
```

## Solution
1. **Created CLI-safe client** (`cli-client.ts`) - Database client without `server-only` import
2. **Added CLI exports** (`@roast/db/cli`) - Separate export path for CLI-safe components  
3. **Updated jobs CLI scripts** - All CLI scripts now import from `@roast/db/cli`
4. **Fixed test mocks** - Updated test mocks to match new import structure
5. **Added validation test** - Test to catch CLI import issues in CI

## Test plan
- [x] All tests pass (`pnpm run test`)
- [x] Jobs CLI commands work (`pnpm run process-jobs`, `pnpm --filter @roast/jobs run process-adaptive`)
- [x] CLI import validation test passes
- [x] No impact on web application functionality

🤖 Generated with [Claude Code](https://claude.ai/code)