### PR TITLE
feat: Revamp navigation for logged-in and logged-out users

### DIFF
--- a/apps/web/src/app/explore/DocumentsResults.tsx
+++ b/apps/web/src/app/explore/DocumentsResults.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import Link from "next/link";
+import { PageLayout } from "@/components/PageLayout";
+import { GradeBadge } from "@/components/GradeBadge";
+import {
+  formatWordCount,
+  getWordCountInfo,
+} from "@/shared/utils/ui/documentUtils";
+import {
+  ChatBubbleLeftIcon,
+  Squares2X2Icon,
+  TableCellsIcon,
+} from "@heroicons/react/24/outline";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { SerializedDocumentListing } from "@/models/DocumentListing.types";
+
+interface DocumentsResultsProps {
+  documents: SerializedDocumentListing[];
+  searchQuery: string;
+  totalCount: number;
+  hasSearched: boolean;
+}
+
+export default function DocumentsResults({
+  documents,
+  searchQuery,
+  totalCount,
+  hasSearched,
+}: DocumentsResultsProps) {
+  // Get unique evaluator names from all documents
+  const evaluators = Array.from(
+    new Set(
+      documents
+        .flatMap(
+          (doc) =>
+            doc.document?.evaluations?.map(
+              (evaluation) => evaluation.agent.name
+            ) || []
+        )
+        .filter(Boolean)
+    )
+  );
+
+  return (
+    <PageLayout>
+      {/* Status message */}
+      {!hasSearched && (
+        <div className="py-2 text-center text-sm text-gray-600">
+          Showing {totalCount} most recent documents. Type at least 2 characters
+          to search all documents.
+        </div>
+      )}
+
+      {hasSearched && (
+        <div className="py-2 text-center text-sm text-gray-600">
+          Found {totalCount} documents matching "{searchQuery}"
+        </div>
+      )}
+
+      {/* Content Section */}
+      <Tabs defaultValue="cards" className="w-full">
+        <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+          <div className="px-4 sm:px-0">
+            <div className="mb-6 flex justify-center">
+              <TabsList>
+                <TabsTrigger value="cards" className="flex items-center gap-2">
+                  <Squares2X2Icon className="h-5 w-5" />
+                  Card View
+                </TabsTrigger>
+                <TabsTrigger value="table" className="flex items-center gap-2">
+                  <TableCellsIcon className="h-5 w-5" />
+                  Table View
+                </TabsTrigger>
+              </TabsList>
+            </div>
+          </div>
+        </div>
+
+        <TabsContent value="cards" className="mt-0">
+          {/* Card View - Keep in container */}
+          <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+            <div className="px-4 sm:px-0">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {documents.map((document) => {
+                  // Count reviews by agent
+                  const agentReviews =
+                    document.document?.evaluations?.reduce(
+                      (acc: Record<string, number>, evaluation) => {
+                        const agentId = evaluation.agentId;
+                        acc[agentId] =
+                          (acc[agentId] || 0) +
+                          (evaluation.latestVersion?.commentCount || 0);
+                        return acc;
+                      },
+                      {} as Record<string, number>
+                    ) || {};
+
+                  return (
+                    <Link
+                      key={document.id}
+                      href={`/docs/${document.document.id}/reader`}
+                      className="block"
+                    >
+                      <Card className="h-full cursor-pointer transition-colors duration-150 hover:bg-gray-50">
+                        <CardHeader className="pb-3">
+                          <CardTitle className="text-base leading-7">
+                            {document.title}
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent className="pt-0">
+                          <div className="mb-2 flex items-center gap-2 text-xs text-gray-500">
+                            <div>{document.authors.join(", ")}</div>
+                            <div className="text-gray-300">•</div>
+                            <div>
+                              {new Date(
+                                document.document.publishedDate
+                              ).toLocaleDateString("en-US", {
+                                month: "short",
+                                day: "numeric",
+                                year: "numeric",
+                              })}
+                            </div>
+                            <div className="text-gray-300">•</div>
+                            <div className="flex items-center gap-1">
+                              {(() => {
+                                const { wordCount, color } = getWordCountInfo(
+                                  document.content
+                                );
+                                return (
+                                  <span className={color}>
+                                    {formatWordCount(wordCount) + " words"}
+                                  </span>
+                                );
+                              })()}
+                            </div>
+                          </div>
+                          {document.urls[0] && (
+                            <div className="mb-3 flex items-center gap-2 truncate text-xs">
+                              <span
+                                className="cursor-pointer text-blue-400 hover:underline"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  window.open(
+                                    document.urls[0],
+                                    "_blank",
+                                    "noopener,noreferrer"
+                                  );
+                                }}
+                              >
+                                {(() => {
+                                  try {
+                                    const url = new URL(document.urls[0]);
+                                    const path = url.pathname.split("/")[1];
+                                    return `${url.hostname}${path ? `/${path}...` : ""}`;
+                                  } catch {
+                                    return document.urls[0];
+                                  }
+                                })()}
+                              </span>
+                              {document.platforms &&
+                                document.platforms.length > 0 && (
+                                  <>
+                                    <div className="text-gray-300">•</div>
+                                    <div className="flex items-center gap-2">
+                                      {document.platforms.map(
+                                        (platform: string) => (
+                                          <span
+                                            key={platform}
+                                            className="inline-flex items-center text-xs font-medium text-blue-500"
+                                          >
+                                            {platform}
+                                          </span>
+                                        )
+                                      )}
+                                    </div>
+                                  </>
+                                )}
+                            </div>
+                          )}
+                          <div className="flex flex-wrap gap-2">
+                            {Object.entries(agentReviews).map(
+                              ([agentId, commentCount]) => {
+                                const evaluation =
+                                  document.document.evaluations.find(
+                                    (r) => r.agentId === agentId
+                                  );
+                                // Just check if grade exists in the evaluation
+                                const hasGrade =
+                                  evaluation?.latestVersion?.grade !== null &&
+                                  evaluation?.latestVersion?.grade !== undefined;
+                                const grade = evaluation?.latestVersion?.grade;
+
+                                return (
+                                  <div
+                                    key={agentId}
+                                    className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
+                                  >
+                                    {evaluation?.agent.name || "Unknown Agent"}
+                                    {hasGrade && (
+                                      <GradeBadge
+                                        grade={grade ?? null}
+                                        className="ml-1 text-xs"
+                                        variant="dark"
+                                      />
+                                    )}
+                                    <ChatBubbleLeftIcon className="ml-2 h-3 w-3 text-gray-400" />{" "}
+                                    <span className="text-gray-500">
+                                      {commentCount}
+                                    </span>
+                                  </div>
+                                );
+                              }
+                            )}
+                            {!document.document?.evaluations?.length && (
+                              <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
+                                No reviews yet
+                              </span>
+                            )}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="table" className="mt-0">
+          {/* Table View - Full width */}
+          <div className="w-full px-4 sm:px-6 lg:px-8">
+            <div className="overflow-x-auto">
+              <div className="min-w-[1200px] px-8">
+                {/* Minimum width to prevent squishing */}
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="max-w-[300px]">Title</TableHead>
+                      <TableHead className="w-32">Author</TableHead>
+                      <TableHead className="w-32">Date</TableHead>
+                      <TableHead className="w-48">Platforms</TableHead>
+                      <TableHead className="w-32">Length</TableHead>
+                      {evaluators.map((evaluator) => (
+                        <TableHead key={evaluator}>{evaluator}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {documents.map((document) => (
+                      <TableRow key={document.id}>
+                        <TableCell className="max-w-[300px]">
+                          <Link
+                            href={`/docs/${document.document.id}/reader`}
+                            className="block truncate text-blue-600 hover:text-blue-900"
+                          >
+                            {document.title}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="w-32">
+                          {document.authors.join(", ")}
+                        </TableCell>
+                        <TableCell className="w-32">
+                          {new Date(
+                            document.document.publishedDate
+                          ).toLocaleDateString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          })}
+                        </TableCell>
+                        <TableCell className="w-48">
+                          <div className="flex flex-wrap gap-2">
+                            {document.platforms?.map((platform: string) => (
+                              <span
+                                key={platform}
+                                className="inline-flex items-center text-xs font-medium text-blue-500"
+                              >
+                                {platform}
+                              </span>
+                            ))}
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-32">
+                          <div className="flex items-center gap-1">
+                            {(() => {
+                              const { wordCount, color } = getWordCountInfo(
+                                document.content
+                              );
+                              return (
+                                <span className={color}>
+                                  {formatWordCount(wordCount) + " words"}
+                                </span>
+                              );
+                            })()}
+                          </div>
+                        </TableCell>
+                        {evaluators.map((evaluator) => {
+                          const evaluation =
+                            document.document?.evaluations?.find(
+                              (r) => r.agent.name === evaluator
+                            );
+                          return (
+                            <TableCell key={evaluator}>
+                              {evaluation?.latestVersion?.grade !== undefined && (
+                                <GradeBadge
+                                  grade={
+                                    evaluation.latestVersion.grade as
+                                      | number
+                                      | null
+                                  }
+                                  className="text-xs"
+                                  variant="dark"
+                                />
+                              )}
+                              {evaluation && (
+                                <span className="ml-2 text-gray-500">
+                                  <ChatBubbleLeftIcon className="inline h-3 w-3 text-gray-400" />
+                                  <span className="ml-1">
+                                    {evaluation.latestVersion?.commentCount || 0}
+                                  </span>
+                                </span>
+                              )}
+                            </TableCell>
+                          );
+                        })}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/app/explore/SearchBar.tsx
+++ b/apps/web/src/app/explore/SearchBar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useDebouncedCallback } from "use-debounce";
+import Link from "next/link";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface SearchBarProps {
+  searchQuery: string;
+  showNewButton?: boolean;
+}
+
+export default function SearchBar({
+  searchQuery: initialSearchQuery,
+  showNewButton = true,
+}: SearchBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+
+  // Update local state when prop changes (e.g., from SSR)
+  useEffect(() => {
+    setSearchQuery(initialSearchQuery);
+  }, [initialSearchQuery]);
+
+  // Debounced search function that updates URL
+  const debouncedSearch = useDebouncedCallback((query: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (query.trim()) {
+      params.set("search", query.trim());
+    } else {
+      params.delete("search");
+    }
+
+    // Reset to page 1 when searching
+    params.delete("page");
+
+    const newUrl = params.toString() ? `?${params.toString()}` : "";
+    router.push(`/docs${newUrl}`);
+  }, 300);
+
+  // Handle search input change
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchQuery(value);
+    debouncedSearch(value);
+  };
+
+  // Handle search input keydown
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      debouncedSearch.flush(); // Immediately execute the search
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8">
+      <div className="px-4 py-6 sm:px-0">
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <div className="flex w-full max-w-2xl justify-between">
+            <div className="relative flex-grow">
+              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+              </div>
+              <Input
+                type="text"
+                value={searchQuery}
+                onChange={handleSearchChange}
+                onKeyDown={handleSearchKeyDown}
+                placeholder="Search by title or agent name..."
+                className="pl-10"
+              />
+            </div>
+            {showNewButton && (
+              <Link href="/docs/new">
+                <Button className="ml-4">New Document</Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/actions/evaluation-actions.ts
+++ b/apps/web/src/app/explore/[docId]/actions/evaluation-actions.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { logger } from "@/infrastructure/logging/logger";
+
+import { auth } from "@/infrastructure/auth/auth";
+import { DocumentModel } from "@/models/Document";
+
+/**
+ * Creates a new job for an evaluation, allowing it to be re-run
+ * with the latest agent version
+ */
+export async function rerunEvaluation(
+  agentId: string,
+  documentId: string
+) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return {
+        success: false,
+        error: "User must be logged in to rerun an evaluation",
+      };
+    }
+
+    await DocumentModel.rerunEvaluation(
+      agentId,
+      documentId,
+      session.user.id
+    );
+
+    // Revalidate pages that might be affected
+    revalidatePath(`/docs/${documentId}/evals/${agentId}`);
+    revalidatePath(`/docs/${documentId}/evals/${agentId}/logs`);
+
+    return { success: true };
+  } catch (error) {
+    logger.error('Error creating job for evaluation:', error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to create job for evaluation",
+    };
+  }
+}
+
+/**
+ * Creates a new evaluation and job for an agent, or reruns existing evaluation
+ */
+export async function createOrRerunEvaluation(
+  agentId: string,
+  documentId: string
+) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return {
+        success: false,
+        error: "User must be logged in to create an evaluation",
+      };
+    }
+
+    await DocumentModel.createOrRerunEvaluation(
+      agentId,
+      documentId,
+      session.user.id
+    );
+
+    // Revalidate the document page
+    revalidatePath(`/docs/${documentId}`);
+
+    return { success: true };
+  } catch (error) {
+    logger.error('Error creating or rerunning evaluation:', error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to create or rerun evaluation",
+    };
+  }
+}

--- a/apps/web/src/app/explore/[docId]/components/EvaluationManagement.tsx
+++ b/apps/web/src/app/explore/[docId]/components/EvaluationManagement.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { 
+  BeakerIcon,
+  ArrowPathIcon,
+  PlusIcon,
+} from "@heroicons/react/24/outline";
+import { AgentBadges } from "@/components/AgentBadges";
+import { createOrRerunEvaluation } from "@/app/docs/[docId]/actions/evaluation-actions";
+import { useEvaluationRerun } from "@/shared/hooks/useEvaluationRerun";
+import { sortAgentsByBadgeStatus } from "@/shared/utils/agentSorting";
+import { ManagementEvaluationCard } from "./ManagementEvaluationCard";
+import type { Evaluation } from "@/shared/types/databaseTypes";
+
+interface Agent {
+  id: string;
+  name: string;
+  description?: string;
+  isDeprecated?: boolean;
+  isRecommended?: boolean;
+  isSystemManaged?: boolean;
+  providesGrades?: boolean;
+}
+
+interface EvaluationManagementProps {
+  docId: string;
+  evaluations: Array<Evaluation & { jobs?: Array<{ status: string }> }>;
+  availableAgents: Agent[];
+  isOwner: boolean;
+}
+
+export function EvaluationManagement({ docId, evaluations, availableAgents, isOwner }: EvaluationManagementProps) {
+  const router = useRouter();
+  const { handleRerun, runningEvals } = useEvaluationRerun({ documentId: docId });
+  const [runningAgents, setRunningAgents] = useState<Set<string>>(new Set());
+  const [sortedAgents, setSortedAgents] = useState<Agent[]>([]);
+
+  // Sort available agents: recommended first, then regular, then deprecated
+  useEffect(() => {
+    const sorted = sortAgentsByBadgeStatus(availableAgents);
+    setSortedAgents(sorted);
+  }, [availableAgents]);
+
+  const handleAddAgent = async (agentId: string) => {
+    setRunningAgents(prev => new Set([...prev, agentId]));
+    try {
+      await createOrRerunEvaluation(agentId, docId);
+      router.refresh();
+    } catch (error) {
+      console.error('Failed to add agent evaluation:', error);
+    } finally {
+      setRunningAgents(prev => {
+        const next = new Set(prev);
+        next.delete(agentId);
+        return next;
+      });
+    }
+  };
+
+
+  return (
+    <>
+      {/* Active Evaluations */}
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+          Active Evaluations ({evaluations.length})
+        </h2>
+        <p className="text-sm text-gray-600 mb-6">
+          Manage and monitor your AI agent evaluations
+        </p>
+
+        <div className="space-y-6">
+          {evaluations.length === 0 ? (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
+              <p className="text-gray-500">No evaluations yet. Add agents below to get started.</p>
+            </div>
+          ) : (
+            evaluations.map((evaluation) => (
+              <ManagementEvaluationCard
+                key={evaluation.agent.id}
+                docId={docId}
+                evaluation={evaluation}
+                isOwner={isOwner}
+                isRunning={runningEvals.has(evaluation.agent.id)}
+                onRerun={handleRerun}
+              />
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Add More Agents */}
+      {isOwner && sortedAgents.length > 0 && (
+        <div className="bg-gray-50 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            Add More Agents
+          </h2>
+          <p className="text-sm text-gray-600 mb-6">
+            Available agents to evaluate your document
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {sortedAgents.slice(0, 10).map((agent) => {
+              const isRunning = runningAgents.has(agent.id);
+
+              return (
+                <div
+                  key={agent.id}
+                  className="bg-white rounded-lg border border-gray-200 p-5 flex items-center justify-between"
+                >
+                  <div className="flex items-start gap-3 flex-1">
+                    <div className="p-1.5">
+                      <BeakerIcon className="h-4 w-4 text-gray-500" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <Link 
+                          href={`/agents/${agent.id}`}
+                          className="font-medium text-gray-900 hover:text-gray-700 truncate"
+                        >
+                          {agent.name}
+                        </Link>
+                        <AgentBadges
+                          isDeprecated={agent.isDeprecated}
+                          isRecommended={agent.isRecommended}
+                          isSystemManaged={agent.isSystemManaged}
+                          providesGrades={agent.providesGrades}
+                          size="sm"
+                        />
+                      </div>
+                      {agent.description && (
+                        <p className="text-sm text-gray-500 line-clamp-2 mt-1">
+                          {agent.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleAddAgent(agent.id)}
+                    disabled={isRunning}
+                    className="ml-4 flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isRunning ? (
+                      <>
+                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                        Adding...
+                      </>
+                    ) : (
+                      <>
+                        <PlusIcon className="h-4 w-4" />
+                        Add
+                      </>
+                    )}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+
+          {sortedAgents.length > 10 && (
+            <p className="text-sm text-gray-500 text-center mt-4">
+              Showing 10 of {sortedAgents.length} available agents
+            </p>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/components/ManagementEvaluationCard.tsx
+++ b/apps/web/src/app/explore/[docId]/components/ManagementEvaluationCard.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { formatDistanceToNow } from "date-fns";
+import Link from "next/link";
+
+import {
+  EvaluationActions,
+} from "@/components/EvaluationCard/shared/EvaluationActions";
+import {
+  EvaluationHeader,
+} from "@/components/EvaluationCard/shared/EvaluationHeader";
+import {
+  EvaluationStats,
+} from "@/components/EvaluationCard/shared/EvaluationStats";
+import { GradeBadge } from "@/components/GradeBadge";
+import { StatusBadge } from "@/components/StatusBadge";
+import type { Evaluation } from "@/shared/types/databaseTypes";
+import { getEvaluationStatus } from "@/shared/utils/evaluationStatus";
+import {
+  ChatBubbleLeftIcon as ChatBubbleLeftIconSolid,
+} from "@heroicons/react/20/solid";
+import {
+  BeakerIcon,
+  DocumentTextIcon,
+} from "@heroicons/react/24/outline";
+
+interface ManagementEvaluationCardProps {
+  docId: string;
+  evaluation: Evaluation & {
+    jobs?: Array<{ status: string }>;
+  };
+  isOwner: boolean;
+  isRunning: boolean;
+  onRerun: (agentId: string) => Promise<void>;
+}
+
+export function ManagementEvaluationCard({
+  docId,
+  evaluation,
+  isOwner,
+  isRunning,
+  onRerun,
+}: ManagementEvaluationCardProps) {
+  const agentId = evaluation.agent.id;
+  const latestVersion = evaluation.versions?.[0];
+  const latestGrade = latestVersion?.grade;
+  const versionCount = evaluation.versions?.length || 0;
+  const isStale = evaluation.isStale || false;
+
+  // Calculate stats
+  const totalCost =
+    evaluation.versions?.reduce((sum: number, v) => {
+      const price = v.job?.priceInDollars;
+      if (!price) return sum;
+      const priceNum =
+        typeof price === "string" ? parseFloat(price) : Number(price);
+      return sum + priceNum;
+    }, 0) || 0;
+
+  const avgDuration =
+    versionCount > 0 && evaluation.versions
+      ? evaluation.versions.reduce(
+          (sum: number, v) => sum + (v.job?.durationInSeconds || 0),
+          0
+        ) / versionCount
+      : 0;
+
+  // Calculate success rate
+  const completedJobs =
+    evaluation.jobs?.filter((job) => job.status === "COMPLETED").length || 0;
+  const totalJobs = evaluation.jobs?.length || 0;
+  const successRate = totalJobs > 0 ? (completedJobs / totalJobs) * 100 : 0;
+
+  // Get evaluation status using shared utility
+  const { latestEvaluationStatus: evaluationStatus, isRerunning } =
+    getEvaluationStatus(evaluation);
+  const latestJobStatus =
+    evaluation.jobs?.[0]?.status || latestVersion?.job?.status || "COMPLETED";
+
+  // Get summary and comment count
+  const latestSummary = latestVersion?.summary || "";
+  const commentCount = latestVersion?.comments?.length || 0;
+
+  // Calculate word count from analysis
+  const analysisWordCount = latestVersion?.analysis
+    ? latestVersion.analysis.trim().split(/\s+/).length
+    : 0;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      {/* Header section */}
+      <div className="px-5 py-4">
+        <div className="flex items-center justify-between">
+          {/* Left side - Agent info */}
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <div className="p-1.5">
+              <BeakerIcon className="h-4 w-4 flex-shrink-0 text-gray-500" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <EvaluationHeader
+                agentName={evaluation.agent.name}
+                grade={latestGrade}
+                isStale={isStale}
+                isRerunning={isRerunning}
+                evaluationStatus={evaluationStatus}
+                showGrade={false}
+              >
+                <Link
+                  href={`/agents/${agentId}`}
+                  className="ml-1 text-gray-400 hover:text-gray-600"
+                >
+                  →
+                </Link>
+              </EvaluationHeader>
+              <div className="mt-0.5">
+                <EvaluationStats
+                  versionCount={versionCount}
+                  successRate={successRate}
+                  avgDuration={avgDuration}
+                  totalCost={totalCost}
+                  docId={docId}
+                  agentId={agentId}
+                  versionNumber={latestVersion?.version}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Right side - Actions */}
+          <div className="ml-4">
+            <EvaluationActions
+              documentId={docId}
+              agentId={agentId}
+              onRerun={isOwner ? () => onRerun(agentId) : undefined}
+              isRunning={
+                isRunning ||
+                latestJobStatus === "PENDING" ||
+                latestJobStatus === "RUNNING"
+              }
+              showRerun={isOwner}
+              showDetails={true}
+              detailsStyle="button"
+              className="flex items-center gap-2"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Recent Eval section */}
+      {latestVersion && (
+        <div className="border-t border-gray-100 bg-gray-50 px-5 py-4">
+          <div className="flex items-start gap-4">
+            {/* Grade badge */}
+            <div className="flex-shrink-0">
+              {latestGrade !== null && latestGrade !== undefined ? (
+                <GradeBadge grade={latestGrade} variant="grayscale" size="md" />
+              ) : (
+                <div className="rounded bg-gray-100 px-3 py-1">
+                  <span className="text-sm font-semibold text-gray-400">
+                    N/A
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Summary and metadata */}
+            <div className="min-w-0 flex-1">
+              <p className="line-clamp-2 text-sm text-gray-700">
+                {latestSummary || "No summary available for this evaluation."}
+              </p>
+              <p className="mt-1 flex items-center gap-2 text-sm text-gray-500">
+                {commentCount > 0 && (
+                  <>
+                    <span className="flex items-center gap-1">
+                      <ChatBubbleLeftIconSolid className="h-3.5 w-3.5 text-gray-400" />
+                      {commentCount}
+                    </span>
+                    <span>•</span>
+                  </>
+                )}
+                {analysisWordCount > 0 && (
+                  <>
+                    <span className="flex items-center gap-1">
+                      <DocumentTextIcon className="h-3.5 w-3.5 text-gray-400" />
+                      {analysisWordCount} words
+                    </span>
+                    <span>•</span>
+                  </>
+                )}
+                <span>
+                  {formatDistanceToNow(
+                    new Date(latestVersion?.createdAt || Date.now()),
+                    { addSuffix: true }
+                  )}
+                </span>
+                {latestVersion?.job && (
+                  <>
+                    <span>•</span>
+                    <Link
+                      href={`/docs/${docId}/evals/${agentId}/logs`}
+                      className="text-purple-700 hover:text-purple-900"
+                    >
+                      Logs
+                    </Link>
+                  </>
+                )}
+                {(evaluationStatus !== "completed" || isRerunning) && (
+                  <>
+                    <span>•</span>
+                    <StatusBadge status={evaluationStatus} showText={true} />
+                  </>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/edit/actions.ts
+++ b/apps/web/src/app/explore/[docId]/edit/actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { logger } from "@/infrastructure/logging/logger";
+
+import { auth } from "@/infrastructure/auth/auth";
+import { DocumentModel } from "@/models/Document";
+
+// This is a raw server action without the client wrapper
+type DocumentUpdateData = {
+  docId: string;
+  title?: string;
+  authors?: string;
+  content: string;
+  urls?: string;
+  platforms?: string;
+  intendedAgents?: string;
+  importUrl?: string;
+};
+
+export async function updateDocument(
+  formData: FormData | DocumentUpdateData
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    // Handle both FormData and direct object submission
+    let docId, data;
+
+    if (formData instanceof FormData) {
+      docId = formData.get("docId") as string;
+      data = {
+        title: formData.get("title") as string,
+        authors: formData.get("authors") as string,
+        content: formData.get("content") as string,
+        urls: formData.get("urls") as string,
+        platforms: formData.get("platforms") as string,
+        intendedAgents: formData.get("intendedAgents") as string,
+        importUrl: formData.get("importUrl") as string,
+      };
+    } else {
+      // Handle direct object submission
+      ({ docId, ...data } = formData);
+    }
+
+    if (!docId) {
+      throw new Error("Document ID is required");
+    }
+
+    // Validate user session
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      throw new Error("User must be logged in to update a document");
+    }
+
+    // Check if the current user is the document owner
+    const isOwner = await DocumentModel.checkOwnership(docId, session.user.id);
+    if (!isOwner) {
+      throw new Error("You don't have permission to update this document");
+    }
+
+    // Update the document
+    await DocumentModel.update(docId, data, session.user.id);
+
+    // Revalidate the document path
+    revalidatePath(`/docs/${docId}`);
+    revalidatePath("/docs");
+
+    // Return success
+    return { success: true };
+  } catch (error) {
+    logger.error('Error updating document:', error);
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to update document",
+    };
+  }
+}

--- a/apps/web/src/app/explore/[docId]/edit/page.tsx
+++ b/apps/web/src/app/explore/[docId]/edit/page.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import {
+  use,
+  useEffect,
+  useState,
+} from "react";
+
+import Link from "next/link";
+import { logger } from "@/infrastructure/logging/logger";
+import { useRouter } from "next/navigation";
+import {
+  FormProvider,
+  useForm,
+} from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/Button";
+import { FormField } from "@/components/FormField";
+import { WarningDialog } from "@/components/WarningDialog";
+
+import {
+  type DocumentInput,
+  documentSchema,
+} from "@/app/docs/new/schema";
+import { updateDocument } from "./actions";
+
+interface FormFieldConfig {
+  name: keyof DocumentInput;
+  label: string;
+  required?: boolean;
+  type: "text" | "textarea";
+  placeholder: string;
+}
+
+const formFields: FormFieldConfig[] = [
+  {
+    name: "title",
+    label: "Title",
+    required: true,
+    type: "text",
+    placeholder: "Document title",
+  },
+  {
+    name: "authors",
+    label: "Authors",
+    required: true,
+    type: "text",
+    placeholder: "Author names (comma separated)",
+  },
+  {
+    name: "urls",
+    label: "URLs",
+    type: "text",
+    placeholder: "Related URLs (comma separated)",
+  },
+  {
+    name: "platforms",
+    label: "Platforms",
+    type: "text",
+    placeholder: "Platforms (e.g., LessWrong, EA Forum)",
+  },
+  {
+    name: "importUrl",
+    label: "Import URL",
+    type: "text",
+    placeholder: "Original URL where this document was imported from",
+  },
+];
+
+type Props = {
+  params: Promise<{
+    docId: string;
+  }>;
+};
+
+export default function EditDocumentPage({ params }: Props) {
+  const router = useRouter();
+  const resolvedParams = use(params);
+  const docId = resolvedParams.docId;
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showWarningDialog, setShowWarningDialog] = useState(false);
+  const [evaluationCount, setEvaluationCount] = useState(0);
+  const [pendingFormData, setPendingFormData] = useState<DocumentInput | null>(null);
+
+  const methods = useForm<DocumentInput>({
+    defaultValues: {
+      title: "",
+      authors: "",
+      content: "",
+      urls: "",
+      platforms: "",
+      importUrl: "",
+    },
+  });
+
+  const {
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError: setFormError,
+    reset,
+  } = methods;
+
+  useEffect(() => {
+    // Fetch the document data from the server
+    const fetchDocument = async () => {
+      try {
+        const response = await fetch(`/api/documents/${docId}`);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch document: ${response.statusText}`);
+        }
+
+        const document = await response.json();
+
+        // Convert the document data to form format
+        reset({
+          title: document.title || "",
+          authors: document.author || "",
+          content: document.content || "",
+          urls: document.url || "",
+          platforms:
+            document.platforms && document.platforms.length > 0
+              ? document.platforms.join(", ")
+              : "",
+          importUrl: document.importUrl || "",
+        });
+
+        // Count the number of evaluations
+        const evalCount = document.reviews?.length || 0;
+        setEvaluationCount(evalCount);
+
+        setLoading(false);
+      } catch (err) {
+        logger.error('Error fetching document:', err);
+        setError(
+          err instanceof Error ? err.message : "Failed to load document data"
+        );
+        setLoading(false);
+      }
+    };
+
+    fetchDocument();
+  }, [docId, reset]);
+
+  const handleConfirmUpdate = async () => {
+    if (!pendingFormData) return;
+    
+    setShowWarningDialog(false);
+    
+    try {
+      const updateResult = await updateDocument({
+        ...pendingFormData,
+        docId: docId,
+      });
+
+      if (!updateResult.success) {
+        setFormError("root", {
+          message: updateResult.error || "Failed to update document",
+        });
+        return;
+      }
+
+      // Redirect to document page
+      router.push(`/docs/${docId}`);
+      router.refresh();
+    } catch (error) {
+      logger.error('Error updating document:', error);
+      setFormError("root", { message: "An unexpected error occurred" });
+    }
+  };
+
+  const handleCancelUpdate = () => {
+    setShowWarningDialog(false);
+    setPendingFormData(null);
+  };
+
+  const onSubmit = async (data: DocumentInput) => {
+    try {
+      const result = documentSchema.parse(data);
+      
+      // If there are evaluations, show warning dialog
+      if (evaluationCount > 0 && !showWarningDialog) {
+        setPendingFormData(result);
+        setShowWarningDialog(true);
+        return;
+      }
+
+      // Use updateDocument for editing with the docId explicitly included
+      const updateResult = await updateDocument({
+        ...result,
+        docId: docId, // Use the resolved docId
+      });
+
+      if (!updateResult.success) {
+        setFormError("root", {
+          message: updateResult.error || "Failed to update document",
+        });
+        return;
+      }
+
+      // Redirect to document page
+      router.push(`/docs/${docId}`);
+      router.refresh(); // Force a refresh to show the updated data
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        error.errors.forEach((err) => {
+          if (err.path[0]) {
+            setFormError(err.path[0].toString() as keyof DocumentInput, {
+              message: err.message,
+            });
+          }
+        });
+      } else {
+        logger.error('Error submitting form:', error);
+        setFormError("root", { message: "An unexpected error occurred" });
+      }
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="mb-4 text-lg font-semibold">
+            Loading document data...
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="rounded-md bg-red-50 p-4">
+          <div className="flex">
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-red-800">Error</h3>
+              <div className="mt-2 text-sm text-red-700">{error}</div>
+              <div className="mt-4">
+                <Link href={`/docs/${docId}`}>
+                  <Button>Back to Document</Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <div className="mb-8">
+            <h1 className="text-2xl font-semibold text-gray-900">
+              Edit Document
+            </h1>
+            <p className="mt-2 text-sm text-gray-600">
+              Update your document (this will create a new version)
+            </p>
+          </div>
+
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+              {formFields.map((field) => (
+                <FormField
+                  key={field.name}
+                  name={field.name}
+                  label={field.label}
+                  required={field.required}
+                  error={errors[field.name]}
+                >
+                  <div>
+                    <input
+                      {...methods.register(field.name)}
+                      type={field.type}
+                      id={field.name}
+                      className={`form-input w-full ${errors[field.name] ? "border-red-500" : ""}`}
+                      placeholder={field.placeholder}
+                    />
+                    {field.name === "importUrl" && (
+                      <p className="mt-2 text-sm text-gray-600">
+                        This is the URL where the document was originally
+                        imported from. It's used for re-importing the document
+                        when you want to fetch the latest version.
+                      </p>
+                    )}
+                  </div>
+                </FormField>
+              ))}
+
+              <FormField
+                name="content"
+                label="Content"
+                required
+                error={errors.content}
+              >
+                <textarea
+                  {...methods.register("content")}
+                  id="content"
+                  rows={15}
+                  className={`form-input w-full ${errors.content ? "border-red-500" : ""}`}
+                  placeholder="Document content in Markdown format"
+                />
+              </FormField>
+
+              {errors.root && (
+                <div className="rounded-md bg-red-50 p-4">
+                  <div className="flex">
+                    <div className="ml-3">
+                      <h3 className="text-sm font-medium text-red-800">
+                        Error
+                      </h3>
+                      <div className="mt-2 text-sm text-red-700">
+                        {errors.root.message}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-3">
+                <Link href={`/docs/${docId}`}>
+                  <Button variant="secondary">Cancel</Button>
+                </Link>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? "Saving..." : "Update Document"}
+                </Button>
+              </div>
+            </form>
+          </FormProvider>
+
+          <WarningDialog
+            isOpen={showWarningDialog}
+            title="Update Document"
+            message={`Updating this document will invalidate ${evaluationCount} existing evaluation${evaluationCount !== 1 ? 's' : ''}. They will be automatically re-run after saving, which will incur API costs. Continue?`}
+            confirmText="Continue with update"
+            onConfirm={handleConfirmUpdate}
+            onCancel={handleCancelUpdate}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/evals/[agentId]/logs/page.tsx
+++ b/apps/web/src/app/explore/[docId]/evals/[agentId]/logs/page.tsx
@@ -1,0 +1,161 @@
+import { notFound } from "next/navigation";
+
+import { prisma } from "@/infrastructure/database/prisma";
+import { evaluationWithCurrentJob } from "@/infrastructure/database/prisma/evaluation-includes";
+import { checkDocumentOwnership } from "@/application/services/document-auth";
+import { BreadcrumbHeader } from "@/components/BreadcrumbHeader";
+import { DocumentEvaluationSidebar } from "@/components/DocumentEvaluationSidebar";
+import { PageHeader } from "@/components/PageHeader";
+import { EvaluationTabsWrapper } from "@/components/EvaluationTabsWrapper";
+import { JobSummary, TaskDisplay } from "@/components/job";
+import { decimalToNumber } from "@/infrastructure/database/prisma-serializers";
+
+interface PageProps {
+  params: Promise<{ 
+    docId: string; 
+    agentId: string;
+  }>;
+}
+
+export default async function EvaluationLogsPage({ params }: PageProps) {
+  const resolvedParams = await params;
+  const { docId, agentId } = resolvedParams;
+
+  // Fetch evaluation and job data
+  const evaluation = await prisma.evaluation.findFirst({
+    where: {
+      documentId: docId,
+      agentId: agentId,
+    },
+    include: evaluationWithCurrentJob,
+  });
+
+  if (!evaluation) {
+    notFound();
+  }
+
+  const agentName = evaluation.agent.versions[0]?.name || "Unknown Agent";
+  const documentTitle = evaluation.document.versions[0]?.title || "Untitled Document";
+  const allEvaluations = evaluation.document.evaluations || [];
+  
+  // Check if current user owns the document
+  const isOwner = await checkDocumentOwnership(docId);
+  
+  // Get the current version and its job
+  const currentVersion = evaluation.versions[0];
+  const currentJob = currentVersion?.job;
+  
+  if (!currentVersion || !currentJob) {
+    return (
+      <div className="h-full bg-gray-50 flex flex-col overflow-hidden">
+        <BreadcrumbHeader 
+          items={[
+            { label: documentTitle, href: `/docs/${docId}` },
+            { label: agentName, href: `/docs/${docId}/evals/${agentId}` },
+            { label: 'Logs' }
+          ]}
+        />
+        <div className="flex-1 flex overflow-hidden">
+          <DocumentEvaluationSidebar 
+            docId={docId}
+            currentAgentId={agentId}
+            evaluations={allEvaluations}
+            isOwner={isOwner}
+          />
+          <div className="flex-1 overflow-y-auto">
+            <PageHeader 
+              title={`${agentName} Evaluation`}
+              layout="with-sidebar"
+            />
+            <EvaluationTabsWrapper docId={docId} agentId={agentId} />
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+              <div className="bg-white rounded-lg shadow p-6 text-center">
+                <p className="text-gray-500">No job data available for the current evaluation version.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full bg-gray-50 flex flex-col overflow-hidden">
+      {/* Breadcrumb Navigation - Full Width */}
+      <BreadcrumbHeader 
+        items={[
+          { label: documentTitle, href: `/docs/${docId}` },
+          { label: agentName, href: `/docs/${docId}/evals/${agentId}` },
+          { label: 'Logs' }
+        ]}
+      />
+      
+      <div className="flex-1 flex overflow-hidden">
+        {/* Document/Evaluation Switcher Sidebar */}
+        <DocumentEvaluationSidebar 
+          docId={docId}
+          currentAgentId={agentId}
+          evaluations={allEvaluations}
+          isOwner={isOwner}
+        />
+        
+        <div className="flex-1 overflow-y-auto">
+          {/* Full-width Header */}
+          <PageHeader 
+            title={`${agentName} Evaluation`}
+            layout="with-sidebar"
+          />
+
+          {/* Tab Navigation */}
+          <EvaluationTabsWrapper 
+            docId={docId} 
+            agentId={agentId} 
+            latestVersionNumber={currentVersion?.version || 1}
+          />
+
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <div className="bg-white rounded-lg shadow">
+              <div className="px-6 py-4 border-b border-gray-200">
+                <h2 className="text-lg font-medium text-gray-900">Job Details</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  Current evaluation job (version {currentVersion.version})
+                </p>
+              </div>
+              
+              <div className="px-6 py-6">
+                <JobSummary 
+                  job={{
+                    id: currentJob.id,
+                    status: currentJob.status,
+                    createdAt: currentJob.createdAt,
+                    completedAt: currentJob.completedAt,
+                    startedAt: currentJob.startedAt,
+                    durationInSeconds: currentJob.durationInSeconds,
+                    priceInDollars: decimalToNumber(currentJob.priceInDollars),
+                    attempts: currentJob.attempts,
+                    originalJobId: currentJob.originalJobId,
+                    error: currentJob.error,
+                    logs: currentJob.logs || undefined
+                  }}
+                  showLogs={true}
+                />
+
+                {/* Task Details */}
+                <div className="mt-6">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-4">Tasks</h3>
+                  <TaskDisplay 
+                    tasks={(currentJob.tasks || []).map(task => ({
+                      ...task,
+                      priceInDollars: Number(task.priceInDollars)
+                    }))} 
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/src/app/explore/[docId]/evals/[agentId]/page.tsx
+++ b/apps/web/src/app/explore/[docId]/evals/[agentId]/page.tsx
@@ -1,0 +1,102 @@
+import { notFound } from "next/navigation";
+
+import { checkDocumentOwnership } from "@/application/services/document-auth";
+import { DocumentEvaluationSidebar } from "@/components/DocumentEvaluationSidebar";
+import { PageHeader } from "@/components/PageHeader";
+import { BreadcrumbHeader } from "@/components/BreadcrumbHeader";
+import { EvaluationTabsWrapper } from "@/components/EvaluationTabsWrapper";
+import { EvaluationContent } from "@/components/evaluation";
+import { getEvaluationForDisplay, extractEvaluationDisplayData } from "@/application/workflows/evaluation/evaluationQueries";
+// Note: serializePrismaResult import removed as it's not used in this file
+
+
+
+
+export default async function EvaluationPage({
+  params,
+}: {
+  params: Promise<{ docId: string; agentId: string }>;
+}) {
+  const resolvedParams = await params;
+  const { docId, agentId } = resolvedParams;
+
+  const evaluation = await getEvaluationForDisplay(docId, agentId);
+
+  if (!evaluation) {
+    notFound();
+  }
+
+  const evaluationData = extractEvaluationDisplayData(evaluation);
+  
+  // Check if current user owns the document (for export functionality only)
+  const isOwner = await checkDocumentOwnership(docId);
+
+  return (
+    <div className="h-full bg-gray-50 flex flex-col overflow-hidden">
+      {/* Breadcrumb Navigation - Full Width */}
+      <BreadcrumbHeader 
+        items={[
+          { label: evaluationData.documentTitle, href: `/docs/${docId}` },
+          { label: evaluationData.agentName }
+        ]}
+      />
+      
+      <div className="flex-1 flex overflow-hidden">
+        {/* Document/Evaluation Switcher Sidebar */}
+        <DocumentEvaluationSidebar 
+          docId={docId}
+          currentAgentId={agentId}
+          evaluations={evaluationData.allEvaluations}
+          isOwner={isOwner}
+        />
+        
+        <div className="flex-1 overflow-y-auto">
+          {/* Full-width Header */}
+          <PageHeader 
+            title={`${evaluationData.agentName} Evaluation`}
+            layout="with-sidebar"
+          />
+
+          {/* Tab Navigation */}
+          <EvaluationTabsWrapper 
+            docId={docId} 
+            agentId={agentId} 
+            latestVersionNumber={evaluationData.version}
+          />
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <EvaluationContent
+            summary={evaluationData.summary}
+            analysis={evaluationData.analysis}
+            thinking={evaluationData.thinking}
+            selfCritique={evaluationData.selfCritique}
+            logs={evaluationData.logs}
+            comments={evaluationData.comments.map(comment => ({
+              ...comment,
+              metadata: comment.metadata as Record<string, any> | null || null
+            }))}
+            agentName={evaluationData.agentName}
+            agentDescription={evaluationData.agentDescription}
+            grade={evaluationData.grade}
+            ephemeralBatch={evaluationData.ephemeralBatch}
+            costInCents={evaluationData.priceInDollars ? Math.round(evaluationData.priceInDollars * 100) : undefined}
+            durationInSeconds={evaluationData.durationInSeconds}
+            createdAt={evaluationData.createdAt.toISOString()}
+            isStale={evaluationData.isStale}
+            showNavigation={true}
+            compact={false}
+            maxWidth="4xl"
+            evaluationData={{
+              agentId: evaluationData.agentId,
+              documentId: evaluationData.documentId,
+              evaluationId: evaluationData.evaluationId,
+            }}
+            isOnEvalPage={true}
+            isOwner={isOwner}
+          />
+        </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/[versionNumber]/logs/TaskDisplayClient.tsx
+++ b/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/[versionNumber]/logs/TaskDisplayClient.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import React from "react";
+
+interface Task {
+  id: string;
+  name: string;
+  modelName: string;
+  priceInDollars: number;
+  timeInSeconds: number | null;
+  log: string | null;
+  llmInteractions?: any; // JSON field from database
+  createdAt: Date;
+}
+
+interface TaskDisplayClientProps {
+  tasks: Task[];
+}
+
+export function TaskDisplayClient({ tasks }: TaskDisplayClientProps) {
+  const [expandedTasks, setExpandedTasks] = React.useState<Set<string>>(new Set());
+  const [jsonViewMode, setJsonViewMode] = React.useState<'pretty' | 'compact'>('pretty');
+
+  if (!tasks || tasks.length === 0) {
+    return (
+      <div className="text-center text-gray-500">
+        No tasks available for this version
+      </div>
+    );
+  }
+
+  const totalCost = tasks.reduce((sum, task) => sum + task.priceInDollars, 0);
+  const totalTime = tasks.reduce((sum, task) => sum + (task.timeInSeconds || 0), 0);
+
+  const toggleTask = (taskId: string) => {
+    const newExpanded = new Set(expandedTasks);
+    if (newExpanded.has(taskId)) {
+      newExpanded.delete(taskId);
+    } else {
+      newExpanded.add(taskId);
+    }
+    setExpandedTasks(newExpanded);
+  };
+
+  return (
+    <div className="space-y-4">
+      {tasks.map((task, index) => {
+        let logData: any = {};
+        let summary = "No log data";
+        
+        try {
+          logData = task.log ? JSON.parse(task.log) : {};
+          summary = logData.summary || summary;
+        } catch {
+          // If log is not JSON, use it as summary
+          summary = task.log || summary;
+        }
+
+        const isExpanded = expandedTasks.has(task.id);
+        const truncatedSummary = summary.length > 200 ? summary.substring(0, 200) + "..." : summary;
+
+        return (
+          <div key={task.id} className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div 
+              className="flex items-center justify-between cursor-pointer hover:bg-gray-100 -m-4 p-4 rounded-t-lg transition-colors"
+              onClick={() => toggleTask(task.id)}
+            >
+              <div className="flex items-center gap-3">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 text-xs font-medium text-white">
+                  {index + 1}
+                </span>
+                <h4 className="font-medium text-gray-900">{task.name}</h4>
+              </div>
+              <div className="flex items-center gap-4 text-sm text-gray-500">
+                <span className={`rounded px-2 py-1 text-xs font-medium ${
+                  task.modelName.includes('gpt-4') ? 'bg-green-100 text-green-800' :
+                  task.modelName.includes('gpt-3.5') ? 'bg-blue-100 text-blue-800' :
+                  task.modelName.includes('claude') ? 'bg-purple-100 text-purple-800' :
+                  task.modelName.includes('gemini') ? 'bg-orange-100 text-orange-800' :
+                  'bg-gray-100 text-gray-800'
+                }`}>
+                  {task.modelName}
+                </span>
+                <span>${task.priceInDollars.toFixed(6)}</span>
+                {task.timeInSeconds && (
+                  <span className="text-gray-600">
+                    {task.timeInSeconds < 60 
+                      ? `${task.timeInSeconds}s`
+                      : `${Math.floor(task.timeInSeconds / 60)}m ${task.timeInSeconds % 60}s`
+                    }
+                  </span>
+                )}
+                <svg 
+                  className="w-5 h-5 transition-transform" 
+                  fill="none" 
+                  stroke="currentColor" 
+                  viewBox="0 0 24 24"
+                >
+                  {isExpanded ? (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+                  ) : (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  )}
+                </svg>
+              </div>
+            </div>
+
+            {/* Summary - Always visible */}
+            <div className="mt-3 text-sm text-gray-700">
+              <strong>Summary:</strong> {truncatedSummary}
+            </div>
+
+            {/* Expandable content */}
+            {isExpanded && (
+              <div className="mt-4 space-y-3 border-t pt-4">
+                {/* Full summary if truncated */}
+                {summary.length > 200 && (
+                  <div className="rounded border border-gray-200 bg-white p-3 text-sm text-gray-700">
+                    <strong>Full Summary:</strong>
+                    <div className="mt-1">{summary}</div>
+                  </div>
+                )}
+
+                {/* LLM Interactions - Check both task.llmInteractions and logData.llmInteractions */}
+                {(() => {
+                  const interactions = task.llmInteractions || logData.llmInteractions;
+                  
+                  if (interactions && Array.isArray(interactions) && interactions.length > 0) {
+                    return (
+                      <div className="rounded-lg border border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 p-4">
+                        <h4 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
+                          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                          </svg>
+                          LLM Interactions
+                        </h4>
+                        {interactions.map((interaction: any, idx: number) => (
+                          <details key={idx} className="mb-3 group" open>
+                            <summary className="cursor-pointer text-sm font-medium text-indigo-900 hover:text-indigo-700 flex items-center gap-2">
+                              <span className="text-lg transition-transform inline-block group-open:rotate-90">▸</span>
+                              Interaction {idx + 1}
+                              {interaction.usage && (
+                                <span className="ml-auto text-xs bg-indigo-100 text-indigo-700 px-2 py-1 rounded-full">
+                                  {interaction.usage.input_tokens.toLocaleString()} → {interaction.usage.output_tokens.toLocaleString()} tokens
+                                </span>
+                              )}
+                            </summary>
+                            <div className="mt-3 space-y-3 pl-6">
+                              {interaction.messages?.map((msg: any, msgIdx: number) => {
+                                // Check if content is JSON
+                                let isJson = false;
+                                let parsedContent = null;
+                                if (typeof msg.content === 'string') {
+                                  const trimmed = msg.content.trim();
+                                  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+                                    try {
+                                      parsedContent = JSON.parse(msg.content);
+                                      isJson = true;
+                                    } catch {
+                                      // Not valid JSON
+                                    }
+                                  }
+                                }
+
+                                return (
+                                  <div key={msgIdx} className={`rounded-lg border ${
+                                    msg.role === 'system' 
+                                      ? 'border-gray-300 bg-gray-50' 
+                                      : 'border-blue-300 bg-blue-50'
+                                  } overflow-hidden`}>
+                                    <div className={`px-3 py-2 font-medium text-sm flex items-center gap-2 ${
+                                      msg.role === 'system' 
+                                        ? 'bg-gray-200 text-gray-700' 
+                                        : 'bg-blue-200 text-blue-700'
+                                    }`}>
+                                      {msg.role === 'system' ? (
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                        </svg>
+                                      ) : (
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                      )}
+                                      {msg.role.charAt(0).toUpperCase() + msg.role.slice(1)}
+                                    </div>
+                                    <div className="p-3">
+                                      {isJson && parsedContent ? (
+                                        <div className="space-y-2">
+                                          {/* JSON Viewer Options */}
+                                          <div className="flex items-center justify-between">
+                                            <span className="text-xs text-gray-500">JSON Response</span>
+                                            <div className="flex items-center gap-2">
+                                              <button
+                                                onClick={(e) => {
+                                                  e.stopPropagation();
+                                                  setJsonViewMode(jsonViewMode === 'pretty' ? 'compact' : 'pretty');
+                                                }}
+                                                className="text-xs text-blue-600 hover:text-blue-800"
+                                              >
+                                                {jsonViewMode === 'pretty' ? 'Compact View' : 'Pretty View'}
+                                              </button>
+                                            </div>
+                                          </div>
+                                          
+                                          {/* JSON Content */}
+                                          <div className="relative group">
+                                            {jsonViewMode === 'pretty' ? (
+                                              <div className="bg-gray-900 text-gray-100 rounded-lg overflow-hidden">
+                                                <div className="sticky top-0 bg-gray-800 px-4 py-2 flex items-center justify-between border-b border-gray-700">
+                                                  <span className="text-xs text-gray-400">JSON</span>
+                                                  <button
+                                                    onClick={(e) => {
+                                                      e.stopPropagation();
+                                                      navigator.clipboard.writeText(JSON.stringify(parsedContent, null, 2));
+                                                      const btn = e.currentTarget;
+                                                      btn.textContent = 'Copied!';
+                                                      btn.classList.add('text-green-400');
+                                                      setTimeout(() => {
+                                                        btn.textContent = 'Copy';
+                                                        btn.classList.remove('text-green-400');
+                                                      }, 2000);
+                                                    }}
+                                                    className="text-xs text-gray-400 hover:text-white transition-colors"
+                                                  >
+                                                    Copy
+                                                  </button>
+                                                </div>
+                                                <div className="p-4 overflow-x-auto max-h-96">
+                                                  <pre className="font-mono text-xs leading-relaxed">
+                                                    <code>{JSON.stringify(parsedContent, null, 2)}</code>
+                                                  </pre>
+                                                </div>
+                                              </div>
+                                            ) : (
+                                              <div className="bg-gray-100 rounded-lg p-3 overflow-x-auto max-h-96">
+                                                <code className="text-xs text-gray-700 break-all">
+                                                  {JSON.stringify(parsedContent)}
+                                                </code>
+                                              </div>
+                                            )}
+                                          </div>
+                                        </div>
+                                      ) : (
+                                        <pre className="whitespace-pre-wrap text-sm text-gray-700 font-mono">{
+                                          typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content, null, 2)
+                                        }</pre>
+                                      )}
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </details>
+                        ))}
+                      </div>
+                    );
+                  }
+                  
+                  // If no interactions but has input/output in logData, show those
+                  if (!interactions && (logData.input || logData.output)) {
+                    return (
+                      <>
+                        {logData.input && (
+                          <div className="rounded border border-green-200 bg-green-50 p-3">
+                            <h4 className="font-medium text-gray-900 mb-2">Input Prompt:</h4>
+                            {typeof logData.input === 'object' ? (
+                              <pre className="overflow-x-auto rounded bg-white p-3 text-xs text-gray-800 border border-gray-200">
+                                {JSON.stringify(logData.input, null, 2)}
+                              </pre>
+                            ) : (
+                              <pre className="whitespace-pre-wrap text-sm text-gray-700">{logData.input}</pre>
+                            )}
+                          </div>
+                        )}
+                        {logData.output && (
+                          <div className="rounded border border-blue-200 bg-blue-50 p-3">
+                            <h4 className="font-medium text-gray-900 mb-2">Output Response:</h4>
+                            {typeof logData.output === 'object' ? (
+                              <pre className="overflow-x-auto rounded bg-white p-3 text-xs text-gray-800 border border-gray-200">
+                                {JSON.stringify(logData.output, null, 2)}
+                              </pre>
+                            ) : (
+                              <pre className="whitespace-pre-wrap text-sm text-gray-700">{logData.output}</pre>
+                            )}
+                          </div>
+                        )}
+                      </>
+                    );
+                  }
+                  
+                  return null;
+                })()}
+
+                {/* All other log data fields */}
+                {Object.entries(logData).map(([key, value]) => {
+                  // Skip already displayed fields
+                  if (['summary', 'input', 'output', 'llmInteractions'].includes(key)) return null;
+                  
+                  return (
+                    <div key={key} className="text-sm border-b border-gray-100 pb-2">
+                      <strong className="text-gray-700">{key}:</strong>
+                      <div className="mt-1">
+                        {typeof value === 'object' && value !== null ? (
+                          <pre className="overflow-x-auto rounded bg-gray-50 p-2 text-xs text-gray-600">
+                            {JSON.stringify(value, null, 2)}
+                          </pre>
+                        ) : (
+                          <span className="text-gray-600"> {String(value)}</span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+
+                {/* Raw log */}
+                {task.log && (
+                  <details className="rounded border bg-white">
+                    <summary className="cursor-pointer px-3 py-2 text-sm font-medium hover:bg-gray-50">
+                      View Raw Log
+                    </summary>
+                    <pre className="overflow-x-auto border-t p-3 text-xs text-gray-700">
+                      {task.log}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Total Summary */}
+      <div className="mt-4 rounded-lg bg-blue-50 p-4">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-blue-900">Total Cost:</span>
+          <span className="text-blue-700">${totalCost.toFixed(4)}</span>
+        </div>
+        <div className="mt-1 flex items-center justify-between text-sm">
+          <span className="font-medium text-blue-900">Total Time:</span>
+          <span className="text-blue-700">
+            {totalTime < 60 
+              ? `${totalTime}s`
+              : `${Math.floor(totalTime / 60)}m ${totalTime % 60}s`
+            }
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/[versionNumber]/logs/page.tsx
+++ b/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/[versionNumber]/logs/page.tsx
@@ -1,0 +1,187 @@
+import { notFound } from "next/navigation";
+
+import { prisma } from "@/infrastructure/database/prisma";
+import { evaluationWithAllVersions } from "@/infrastructure/database/prisma/evaluation-includes";
+import { checkDocumentOwnership } from "@/application/services/document-auth";
+import { BreadcrumbHeader } from "@/components/BreadcrumbHeader";
+import { DocumentEvaluationSidebar } from "@/components/DocumentEvaluationSidebar";
+import { EvaluationVersionSidebar } from "@/components/EvaluationVersionSidebar";
+import { VersionPageHeader } from "@/components/VersionPageHeader";
+import { VersionTabs } from "@/components/VersionTabs";
+import { TaskDisplayClient } from "./TaskDisplayClient";
+import { CopyButton } from "@/components/CopyButton";
+
+interface PageProps {
+  params: Promise<{ 
+    docId: string; 
+    agentId: string;
+    versionNumber: string;
+  }>;
+}
+
+
+export default async function VersionLogsPage({ params }: PageProps) {
+  const resolvedParams = await params;
+  const { docId, agentId, versionNumber } = resolvedParams;
+  const versionNum = parseInt(versionNumber);
+
+  if (!docId || !agentId || isNaN(versionNum)) {
+    notFound();
+  }
+
+  // Fetch the evaluation with all versions
+  const evaluation = await prisma.evaluation.findFirst({
+    where: {
+      documentId: docId,
+      agentId: agentId,
+    },
+    include: evaluationWithAllVersions,
+  });
+
+  if (!evaluation) {
+    notFound();
+  }
+
+  // Find the specific version
+  const selectedVersion = evaluation.versions.find(v => v.version === versionNum);
+  
+  if (!selectedVersion || !selectedVersion.job) {
+    notFound();
+  }
+
+  const job = selectedVersion.job;
+  const agentName = evaluation.agent.versions[0]?.name || "Unknown Agent";
+  const documentTitle = evaluation.document.versions[0]?.title || "Untitled Document";
+  
+  // Get all evaluations for the sidebar
+  const allEvaluations = evaluation.document.evaluations || [];
+  
+  // Check if current user owns the document
+  const isOwner = await checkDocumentOwnership(docId);
+
+  return (
+    <div className="h-full bg-gray-50 flex flex-col overflow-hidden">
+      {/* Breadcrumb Navigation - Full Width */}
+      <BreadcrumbHeader 
+        items={[
+          { label: documentTitle, href: `/docs/${docId}` },
+          { label: agentName, href: `/docs/${docId}/evals/${agentId}` },
+          { label: `V${versionNum}`, href: `/docs/${docId}/evals/${agentId}/versions/${versionNum}` },
+          { label: 'Logs' }
+        ]}
+      />
+      
+      <div className="flex-1 flex overflow-hidden">
+        {/* Document/Evaluation Switcher Sidebar */}
+        <DocumentEvaluationSidebar 
+          docId={docId}
+          currentAgentId={agentId}
+          evaluations={allEvaluations}
+          isOwner={isOwner}
+        />
+        
+        {/* Version Sidebar */}
+        <EvaluationVersionSidebar
+          docId={docId}
+          agentId={agentId}
+          versions={evaluation.versions}
+          currentVersion={versionNum}
+          isOwner={isOwner}
+        />
+        
+        <div className="flex-1 overflow-y-auto">
+          {/* Full-width Header */}
+          <VersionPageHeader 
+            title={`${agentName} Evaluation (v${versionNum})`}
+            layout="with-sidebar"
+            docId={docId}
+            agentId={agentId}
+          />
+
+          {/* Tab Navigation */}
+          <VersionTabs docId={docId} agentId={agentId} versionNumber={versionNum} />
+
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <div className="bg-white rounded-lg shadow">
+              <div className="px-6 py-4 border-b border-gray-200">
+                <h2 className="text-lg font-medium text-gray-900">Job Details</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  Execution details for version {versionNum}
+                </p>
+              </div>
+              
+              <div className="px-6 py-6">
+                {/* Job Status and Basic Info */}
+                <div className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-700 mb-1">Status</h3>
+                    <span className={cn(
+                      "inline-flex items-center px-3 py-1 rounded-full text-sm font-medium",
+                      job.status === 'COMPLETED' ? 'bg-green-100 text-green-800' : 
+                      job.status === 'FAILED' ? 'bg-red-100 text-red-800' : 
+                      'bg-yellow-100 text-yellow-800'
+                    )}>
+                      {job.status.toLowerCase()}
+                    </span>
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-700 mb-1">Job ID</h3>
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm text-gray-900 font-mono">{job.id}</p>
+                      <CopyButton text={job.id} />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Timestamps */}
+                {(job.startedAt || job.completedAt) && (
+                  <div className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {job.startedAt && (
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-700 mb-1">Started</h3>
+                        <p className="text-sm text-gray-900">
+                          {new Date(job.startedAt).toLocaleString()}
+                        </p>
+                      </div>
+                    )}
+                    {job.completedAt && (
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-700 mb-1">Completed</h3>
+                        <p className="text-sm text-gray-900">
+                          {new Date(job.completedAt).toLocaleString()}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Error Message */}
+                {job.error && (
+                  <div className="mb-6">
+                    <h3 className="text-sm font-medium text-gray-700 mb-2">Error</h3>
+                    <div className="p-3 bg-red-50 rounded-md">
+                      <p className="text-sm text-red-800">{job.error}</p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Task Details */}
+                <div className="mt-6">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-4">Tasks</h3>
+                  <TaskDisplayClient tasks={(job.tasks || []).map(task => ({
+                    ...task,
+                    priceInDollars: Number(task.priceInDollars)
+                  }))} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function cn(...classes: (string | boolean | undefined)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/[versionNumber]/page.tsx
+++ b/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/[versionNumber]/page.tsx
@@ -1,0 +1,402 @@
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
+
+import { prisma } from "@/infrastructure/database/prisma";
+import { evaluationWithAllVersions } from "@/infrastructure/database/prisma/evaluation-includes";
+import { checkDocumentOwnership } from "@/application/services/document-auth";
+import { serializePrismaResult } from "@/infrastructure/database/prisma-serializers";
+import { EvaluationNavigation } from "@/components/EvaluationNavigation";
+import { DocumentEvaluationSidebar } from "@/components/DocumentEvaluationSidebar";
+import { EvaluationVersionSidebar } from "@/components/EvaluationVersionSidebar";
+import { GradeBadge } from "@/components/GradeBadge";
+import { VersionPageHeader } from "@/components/VersionPageHeader";
+import { BreadcrumbHeader } from "@/components/BreadcrumbHeader";
+import { VersionTabs } from "@/components/VersionTabs";
+
+// Function to extract headings from markdown
+function extractHeadings(markdown: string, minLevel: number = 1): { id: string; label: string; level: number }[] {
+  const headings: { id: string; label: string; level: number }[] = [];
+  const lines = markdown.split('\n');
+  
+  lines.forEach((line) => {
+    // Match markdown headings (# and ##)
+    const match = line.match(/^(#{1,2})\s+(.+)$/);
+    if (match) {
+      const level = match[1].length;
+      const text = match[2].trim();
+      // Create a slug from the heading text
+      const id = text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      
+      if (level >= minLevel && level <= 2) { // Only include headings at minLevel or higher
+        headings.push({
+          id,
+          label: text,
+          level
+        });
+      }
+    }
+  });
+  
+  return headings;
+}
+
+// Function to create markdown components with heading IDs
+function createMarkdownComponents(sectionPrefix: string) {
+  return {
+    // Style headings with IDs
+    h1: ({ children }: any) => {
+      const text = String(children);
+      const id = `${sectionPrefix}-${text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')}`;
+      return (
+        <h1 id={id} className="text-2xl font-bold text-gray-900 mt-8 mb-4 first:mt-0 scroll-mt-8">
+          {children}
+        </h1>
+      );
+    },
+    h2: ({ children }: any) => {
+      const text = String(children);
+      const id = `${sectionPrefix}-${text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')}`;
+      return (
+        <h2 id={id} className="text-xl font-semibold text-gray-800 mt-6 mb-3 scroll-mt-8">
+          {children}
+        </h2>
+      );
+    },
+    h3: ({ children }: any) => (
+      <h3 className="text-lg font-medium text-gray-800 mt-4 mb-2">
+        {children}
+      </h3>
+    ),
+    // Style paragraphs
+    p: ({ children }: any) => (
+      <p className="text-gray-700 leading-relaxed mb-4">
+        {children}
+      </p>
+    ),
+    // Style lists
+    ul: ({ children }: any) => (
+      <ul className="list-disc list-inside space-y-2 mb-4 text-gray-700">
+        {children}
+      </ul>
+    ),
+    ol: ({ children }: any) => (
+      <ol className="list-decimal list-inside space-y-2 mb-4 text-gray-700">
+        {children}
+      </ol>
+    ),
+    // Style blockquotes
+    blockquote: ({ children }: any) => (
+      <blockquote className="border-l-4 border-gray-300 pl-4 py-2 my-4 text-gray-600 italic">
+        {children}
+      </blockquote>
+    ),
+    // Style code blocks
+    pre: ({ children }: any) => (
+      <pre className="bg-gray-100 rounded-md p-4 overflow-x-auto mb-4">
+        {children}
+      </pre>
+    ),
+    code: ({ children }: any) => (
+      <code className="bg-gray-100 rounded px-1 py-0.5 text-sm">
+        {children}
+      </code>
+    ),
+    // Style links
+    a: ({ href, children }: any) => (
+      <a href={href} className="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    ),
+    // Style horizontal rules
+    hr: () => (
+      <hr className="my-8 border-gray-200" />
+    ),
+  };
+}
+
+interface PageProps {
+  params: Promise<{ 
+    docId: string; 
+    agentId: string;
+    versionNumber: string;
+  }>;
+}
+
+export default async function EvaluationVersionPage({ params }: PageProps) {
+  const resolvedParams = await params;
+  const { docId, agentId, versionNumber } = resolvedParams;
+  const versionNum = parseInt(versionNumber);
+
+  if (!docId || !agentId || isNaN(versionNum)) {
+    notFound();
+  }
+
+  // Fetch the evaluation with all versions
+  const evaluationRaw = await prisma.evaluation.findFirst({
+    where: {
+      documentId: docId,
+      agentId: agentId,
+    },
+    include: evaluationWithAllVersions,
+  });
+
+  if (!evaluationRaw) {
+    notFound();
+  }
+
+  // Serialize the evaluation to handle Decimal fields
+  const evaluation = serializePrismaResult(evaluationRaw);
+
+  // Find the specific version
+  const selectedVersion = evaluation.versions.find(v => v.version === versionNum);
+  
+  if (!selectedVersion) {
+    notFound();
+  }
+
+  // Extract content from the selected version
+  const analysis = selectedVersion.analysis || "No analysis available";
+  const summary = selectedVersion.summary || "";
+  const thinking = selectedVersion.job?.llmThinking || "";
+  const selfCritique = selectedVersion.selfCritique || "";
+  const grade = selectedVersion.grade;
+
+  // Agent information
+  const agentName = evaluation.agent.versions[0]?.name || "Unknown Agent";
+  const agentDescription = evaluation.agent.versions[0]?.description || "";
+  const documentTitle = evaluation.document.versions[0]?.title || "Untitled Document";
+  
+  // Extract cost and duration - they're already serialized to strings/proper types
+  const priceInDollars = selectedVersion.job?.priceInDollars;
+  const costInCents = priceInDollars ? Math.round(parseFloat(String(priceInDollars)) * 100) : null;
+  const durationInSeconds = selectedVersion.job?.durationInSeconds 
+    ? Number(selectedVersion.job?.durationInSeconds) 
+    : null;
+  
+  // Get all evaluations for the sidebar - already serialized by serializePrismaResult
+  const allEvaluations = evaluation.document.evaluations || [];
+  
+  // Check if current user owns the document
+  const isOwner = await checkDocumentOwnership(docId);
+
+  // Extract headings from each section
+  const analysisHeadings = analysis ? extractHeadings(analysis, 2) : []; // Only H2 for analysis
+  const thinkingHeadings = thinking ? extractHeadings(thinking) : []; // H1 and H2 for thinking
+  const selfCritiqueHeadings = selfCritique ? extractHeadings(selfCritique) : []; // H1 and H2 for self-critique
+
+  // Create navigation items with sub-items
+  const navItems = [
+    { 
+      id: 'summary', 
+      label: 'Summary', 
+      show: !!summary,
+      subItems: []
+    },
+    { 
+      id: 'agent-info', 
+      label: 'Agent Information', 
+      show: true,
+      subItems: []
+    },
+    { 
+      id: 'analysis', 
+      label: 'Analysis', 
+      show: true,
+      subItems: analysisHeadings.map(h => ({ ...h, id: `analysis-${h.id}` }))
+    },
+    { 
+      id: 'thinking', 
+      label: 'Thinking Process', 
+      show: !!thinking,
+      subItems: thinkingHeadings.map(h => ({ ...h, id: `thinking-${h.id}` }))
+    },
+    { 
+      id: 'self-critique', 
+      label: 'Self-Critique', 
+      show: !!selfCritique,
+      subItems: selfCritiqueHeadings.map(h => ({ ...h, id: `self-critique-${h.id}` }))
+    },
+    { 
+      id: 'run-stats', 
+      label: 'Run Stats', 
+      show: !!(costInCents || durationInSeconds != null),
+      subItems: []
+    },
+  ].filter(item => item.show);
+
+  return (
+    <div className="h-full bg-gray-50 flex flex-col overflow-hidden">
+      {/* Breadcrumb Navigation - Full Width */}
+      <BreadcrumbHeader 
+        items={[
+          { label: documentTitle, href: `/docs/${docId}` },
+          { label: agentName, href: `/docs/${docId}/evals/${agentId}` },
+          { label: `V${versionNum}` }
+        ]}
+      />
+      
+      <div className="flex-1 flex overflow-hidden">
+        {/* Document/Evaluation Switcher Sidebar */}
+        <DocumentEvaluationSidebar 
+          docId={docId}
+          currentAgentId={agentId}
+          evaluations={allEvaluations}
+          isOwner={isOwner}
+        />
+        
+        {/* Version Sidebar */}
+        <EvaluationVersionSidebar
+          docId={docId}
+          agentId={agentId}
+          versions={evaluation.versions}
+          currentVersion={versionNum}
+          isOwner={isOwner}
+        />
+        
+        <div className="flex-1 overflow-y-auto">
+          {/* Full-width Header */}
+          <VersionPageHeader 
+            title={`${agentName} Evaluation (v${versionNum})`}
+            layout="with-sidebar"
+            docId={docId}
+            agentId={agentId}
+          />
+
+          {/* Tab Navigation */}
+          <VersionTabs docId={docId} agentId={agentId} versionNumber={versionNum} />
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="flex gap-8">
+            {/* Main Content */}
+            <div id="evaluation-content" className="flex-1 max-w-4xl">
+
+        {/* Summary Section */}
+        {summary && (
+          <div id="summary" className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 mb-6 scroll-mt-8">
+            <div className="border-b border-gray-200 pb-4 mb-6">
+              <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wider">Summary</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">{summary}</p>
+          </div>
+        )}
+
+        {/* Agent Info Card */}
+        <div id="agent-info" className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6 scroll-mt-8">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <h3 className="text-lg font-semibold text-gray-900 mb-1">{agentName}</h3>
+              {agentDescription && (
+                <p className="text-sm text-gray-600 mb-2">{agentDescription}</p>
+              )}
+            </div>
+            {grade && (
+              <div className="ml-4">
+                <GradeBadge grade={grade} variant="dark" size="md" />
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Analysis Section */}
+        <div id="analysis" className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 mb-6 scroll-mt-8">
+          <div className="border-b border-gray-200 pb-4 mb-6">
+            <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wider">Analysis</h2>
+          </div>
+          <div className="prose prose-gray max-w-none">
+            {analysis ? (
+              <ReactMarkdown 
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={createMarkdownComponents('analysis')}
+              >
+                {analysis}
+              </ReactMarkdown>
+            ) : (
+              <p className="text-gray-500 italic">No analysis available</p>
+            )}
+          </div>
+        </div>
+
+        {/* Thinking Process Section */}
+        {thinking && (
+          <div id="thinking" className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 mb-6 scroll-mt-8">
+            <div className="border-b border-gray-200 pb-4 mb-6">
+              <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wider">Thinking Process</h2>
+            </div>
+            <div className="prose prose-gray max-w-none">
+              <ReactMarkdown 
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={createMarkdownComponents('thinking')}
+              >
+                {thinking}
+              </ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* Self-Critique Section */}
+        {selfCritique && (
+          <div id="self-critique" className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 mb-6 scroll-mt-8">
+            <div className="border-b border-gray-200 pb-4 mb-6">
+              <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wider">Self-Critique</h2>
+            </div>
+            <div className="prose prose-gray max-w-none">
+              <ReactMarkdown 
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={createMarkdownComponents('self-critique')}
+              >
+                {selfCritique}
+              </ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* Run Stats Section */}
+        {(costInCents || durationInSeconds != null) && (
+          <div id="run-stats" className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6 scroll-mt-8">
+            <div className="border-b border-gray-200 pb-4 mb-4">
+              <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wider">Run Statistics</h2>
+            </div>
+            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {costInCents && (
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Cost</dt>
+                  <dd className="mt-1 text-2xl font-semibold text-gray-900">
+                    ${(costInCents / 100).toFixed(3)}
+                  </dd>
+                </div>
+              )}
+              {durationInSeconds != null && (
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Duration</dt>
+                  <dd className="mt-1 text-2xl font-semibold text-gray-900">
+                    {durationInSeconds < 60 
+                      ? `${durationInSeconds}s`
+                      : `${Math.floor(durationInSeconds / 60)}m ${durationInSeconds % 60}s`
+                    }
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        )}
+      </div>
+
+            {/* Right Navigation Sidebar */}
+            <div className="hidden xl:block">
+              <EvaluationNavigation items={navItems} />
+            </div>
+          </div>
+        </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/page.tsx
+++ b/apps/web/src/app/explore/[docId]/evals/[agentId]/versions/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { prisma } from "@/infrastructure/database/prisma";
+
+interface PageProps {
+  params: Promise<{ 
+    docId: string; 
+    agentId: string;
+  }>;
+}
+
+export default async function VersionsRedirectPage({ params }: PageProps) {
+  const resolvedParams = await params;
+  const { docId, agentId } = resolvedParams;
+
+  // Get the latest version
+  const latestVersion = await prisma.evaluationVersion.findFirst({
+    where: {
+      evaluation: {
+        documentId: docId,
+        agentId: agentId,
+      },
+    },
+    orderBy: {
+      version: 'desc',
+    },
+    select: {
+      version: true,
+    },
+  });
+
+  // Redirect to the latest version, or version 1 if none found
+  const versionNumber = latestVersion?.version || 1;
+  redirect(`/docs/${docId}/evals/${agentId}/versions/${versionNumber}`);
+}

--- a/apps/web/src/app/explore/[docId]/page.tsx
+++ b/apps/web/src/app/explore/[docId]/page.tsx
@@ -1,0 +1,363 @@
+import { formatDistanceToNow } from "date-fns";
+// @ts-expect-error - No types available for markdown-truncate
+import truncateMarkdown from "markdown-truncate";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { BreadcrumbHeader } from "@/components/BreadcrumbHeader";
+import { DocumentActions } from "@/components/DocumentActions";
+import { DocumentEvaluationSidebar } from "@/components/DocumentEvaluationSidebar";
+import SlateEditor from "@/components/SlateEditor";
+import { PageHeader } from "@/components/PageHeader";
+import { ExperimentalBadge } from "@/components/ExperimentalBadge";
+import { auth } from "@/infrastructure/auth/auth";
+import { prisma } from "@/infrastructure/database/prisma";
+import { DocumentModel } from "@/models/Document";
+import {
+  ArrowTopRightOnSquareIcon,
+  BookOpenIcon,
+} from "@heroicons/react/24/outline";
+import { EvaluationManagement } from "./components/EvaluationManagement";
+
+async function getAvailableAgents(docId: string) {
+  // Get all agents that don't have evaluations for this document yet
+  const existingEvaluations = await prisma.evaluation.findMany({
+    where: { documentId: docId },
+    select: { agentId: true },
+  });
+
+  const existingAgentIds = existingEvaluations.map((e) => e.agentId);
+
+  const agents = await prisma.agent.findMany({
+    where: {
+      id: { notIn: existingAgentIds },
+      ephemeralBatchId: null, // Exclude ephemeral agents
+    },
+    include: {
+      versions: {
+        orderBy: { version: "desc" },
+        take: 1,
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return agents.map((agent) => ({
+    id: agent.id,
+    name: agent.versions[0]?.name || "Unknown Agent",
+    description: agent.versions[0]?.description || undefined,
+    purpose: undefined,
+    isRecommended: agent.isRecommended,
+    isDeprecated: agent.isDeprecated,
+    isSystemManaged: agent.isSystemManaged,
+    providesGrades: agent.versions[0]?.providesGrades || false,
+  }));
+}
+
+export default async function DocumentPage({
+  params,
+}: {
+  params: Promise<{ docId: string }>;
+}) {
+  const resolvedParams = await params;
+  const docId = resolvedParams.docId;
+  const session = await auth();
+  const currentUserId = session?.user?.id;
+
+  if (!docId) {
+    notFound();
+  }
+
+  // Use getDocumentWithAllEvaluations to show all evaluations in the sidebar
+  // regardless of staleness - users should always see their evaluations
+  const document = await DocumentModel.getDocumentWithAllEvaluations(docId);
+
+  if (!document) {
+    notFound();
+  }
+
+  // Get ephemeral batch information
+  const documentWithBatch = await prisma.document.findUnique({
+    where: { id: docId },
+    select: {
+      ephemeralBatch: {
+        select: {
+          trackingId: true,
+          isEphemeral: true,
+        },
+      },
+    },
+  });
+
+  const isOwner = currentUserId
+    ? document.submittedById === currentUserId
+    : false;
+
+  // Get word count from document content
+  const wordCount = document.content?.trim().split(/\s+/).length || 0;
+
+  // Calculate file size from content (estimate based on UTF-8 encoding)
+  const contentSizeBytes = new TextEncoder().encode(
+    document.content || ""
+  ).length;
+  const fileSizeKB = contentSizeBytes / 1024;
+  const fileSize =
+    fileSizeKB > 1024
+      ? `${(fileSizeKB / 1024).toFixed(1)} MB`
+      : `${Math.round(fileSizeKB)} KB`;
+
+  // Transform reviews to match the expected Evaluation interface
+  const evaluations =
+    document.reviews?.map((review) => ({
+      id: review.id,
+      agentId: review.agent.id,
+      agent: {
+        name: review.agent.name,
+        versions: [
+          {
+            name: review.agent.name,
+          },
+        ],
+      },
+      versions: review.versions?.map((version) => ({
+        grade: version.grade,
+        job: review.jobs?.[0]
+          ? {
+              status: review.jobs[0].status as
+                | "PENDING"
+                | "RUNNING"
+                | "COMPLETED"
+                | "FAILED",
+            }
+          : undefined,
+      })),
+      jobs: review.jobs?.map((job) => ({
+        status: job.status as "PENDING" | "RUNNING" | "COMPLETED" | "FAILED",
+      })),
+    })) || [];
+
+  const availableAgents = await getAvailableAgents(docId);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-gray-50">
+      {/* Full-width breadcrumbs */}
+      <BreadcrumbHeader
+        items={[
+          { label: document.title || "Untitled Document" },
+          { label: "Overview" },
+        ]}
+      />
+
+      {/* Sidebar and content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Document/Evaluation Switcher Sidebar */}
+        <DocumentEvaluationSidebar
+          docId={docId}
+          evaluations={evaluations}
+          isOwner={isOwner}
+        />
+
+        <div className="flex-1 overflow-y-auto">
+          {/* Full-width Header */}
+          <PageHeader
+            title={document.title || "Untitled Document"}
+            subtitle="Document Overview"
+          >
+            <div className="flex items-center gap-4">
+              {documentWithBatch?.ephemeralBatch && (
+                <ExperimentalBadge 
+                  trackingId={documentWithBatch.ephemeralBatch.trackingId}
+                />
+              )}
+              {isOwner && (
+                <DocumentActions
+                  docId={docId}
+                  document={{ importUrl: document.importUrl }}
+                />
+              )}
+            </div>
+          </PageHeader>
+
+          <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+            <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+              {/* Main Content */}
+              <div className="lg:col-span-2">
+                {/* Document Preview Card */}
+                <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="mb-6 text-lg font-semibold text-gray-900">
+                    Document Opening
+                  </h2>
+
+                  <div className="prose prose-gray max-w-none">
+                    {document.content ? (
+                      <div className="leading-relaxed text-gray-700">
+                        <SlateEditor 
+                          content={truncateMarkdown(document.content, {
+                            limit: 500,
+                            ellipsis: true,
+                          })}
+                          highlights={[]}
+                        />
+                      </div>
+                    ) : (
+                      <p className="italic text-gray-500">
+                        No content available
+                      </p>
+                    )}
+
+                    <p className="mt-4 text-sm text-gray-500">
+                      Blog Post • First paragraph preview
+                    </p>
+                  </div>
+
+                  <div className="mt-6 flex gap-3">
+                    {document.importUrl ? (
+                      <a
+                        href={document.importUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+                      >
+                        <ArrowTopRightOnSquareIcon className="mr-2 h-4 w-4" />
+                        Go to source
+                      </a>
+                    ) : (
+                      <Link
+                        href={`/docs/${docId}/reader`}
+                        className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+                      >
+                        <BookOpenIcon className="mr-2 h-4 w-4" />
+                        View full document
+                      </Link>
+                    )}
+                    <Link
+                      href={`/docs/${docId}/reader`}
+                      className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                    >
+                      <BookOpenIcon className="mr-2 h-4 w-4" />
+                      Reader View
+                    </Link>
+                  </div>
+                </div>
+              </div>
+
+              {/* Right Sidebar */}
+              <div className="lg:col-span-1">
+                <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="mb-6 text-lg font-semibold text-gray-900">
+                    Document Information
+                  </h2>
+
+                  <dl className="space-y-4">
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">
+                        Document Title
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {document.title || "Untitled"}
+                      </dd>
+                    </div>
+
+                    {document.importUrl && (
+                      <div>
+                        <dt className="text-sm font-medium text-gray-500">
+                          Blog URL
+                        </dt>
+                        <dd className="mt-1">
+                          <a
+                            href={document.importUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="break-all text-sm text-blue-600 hover:text-blue-800"
+                          >
+                            {document.importUrl}
+                          </a>
+                        </dd>
+                      </div>
+                    )}
+
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">
+                        File Size
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">{fileSize}</dd>
+                    </div>
+
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">
+                        Word Count
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {wordCount.toLocaleString()} words
+                      </dd>
+                    </div>
+
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">
+                        Upload Date
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {formatDistanceToNow(new Date(document.createdAt), {
+                          addSuffix: true,
+                        })}
+                      </dd>
+                    </div>
+
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">
+                        Uploaded By
+                      </dt>
+                      <dd className="mt-1 flex items-center gap-2">
+                        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-200">
+                          <span className="text-xs font-medium text-gray-600">
+                            {document.submittedBy?.name
+                              ?.charAt(0)
+                              ?.toUpperCase() ||
+                              document.submittedBy?.email
+                                ?.charAt(0)
+                                ?.toUpperCase() ||
+                              "?"}
+                          </span>
+                        </div>
+                        <span className="text-sm text-gray-900">
+                          {document.submittedBy?.name ||
+                            document.submittedBy?.email ||
+                            "Unknown"}
+                        </span>
+                      </dd>
+                    </div>
+
+                    {document.author && (
+                      <div>
+                        <dt className="mb-2 text-sm font-medium text-gray-500">
+                          Authors
+                        </dt>
+                        <dd className="space-y-2">
+                          {document.author.split(",").map((author, index) => (
+                            <div key={index} className="text-sm text-gray-900">
+                              {author.trim()}
+                            </div>
+                          ))}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                </div>
+              </div>
+            </div>
+
+            {/* Evaluation Management Section */}
+            <div className="mt-8">
+              <EvaluationManagement
+                docId={docId}
+                evaluations={document.reviews || []}
+                availableAgents={availableAgents}
+                isOwner={isOwner}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/[docId]/reader/actions.ts
+++ b/apps/web/src/app/explore/[docId]/reader/actions.ts
@@ -1,0 +1,136 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { logger } from "@/infrastructure/logging/logger";
+
+import { auth } from "@/infrastructure/auth/auth";
+import { processArticle } from "@/infrastructure/external/articleImport";
+import { NotFoundError, AuthorizationError } from '@roast/domain';
+import { getServices } from "@/application/services/ServiceFactory";
+
+export async function deleteDocument(docId: string) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return {
+        success: false,
+        error: "User must be logged in to delete a document",
+      };
+    }
+
+    // Delete the document using the service
+    const { documentService } = getServices();
+    const result = await documentService.deleteDocument(docId, session.user.id);
+    
+    if (result.isError()) {
+      const error = result.error();
+      if (error instanceof NotFoundError) {
+        return {
+          success: false,
+          error: "Document not found",
+        };
+      }
+      if (error instanceof AuthorizationError) {
+        return {
+          success: false,
+          error: "You don't have permission to delete this document",
+        };
+      }
+      return {
+        success: false,
+        error: error?.message || "Failed to delete document",
+      };
+    }
+
+    // Revalidate documents path
+    revalidatePath("/docs");
+
+    // Return success response (will cause client-side redirect)
+    return { success: true, redirectTo: "/docs" };
+  } catch (error) {
+    logger.error('Error deleting document:', error);
+    return { success: false, error: "Failed to delete document" };
+  }
+}
+
+export async function reuploadDocument(docId: string) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return {
+        success: false,
+        error: "User must be logged in to re-upload a document",
+      };
+    }
+
+    // Check ownership using the service
+    const { documentService } = getServices();
+    const ownershipResult = await documentService.checkOwnership(docId, session.user.id);
+    if (ownershipResult.isError()) {
+      return {
+        success: false,
+        error: "You don't have permission to re-upload this document",
+      };
+    }
+    
+    if (!ownershipResult.unwrap()) {
+      return {
+        success: false,
+        error: "You don't have permission to re-upload this document",
+      };
+    }
+
+    // Get the current document to extract its URL
+    const docResult = await documentService.getDocumentForReader(docId, session.user.id);
+    if (docResult.isError()) {
+      return {
+        success: false,
+        error: "Document not found",
+      };
+    }
+    
+    const document = docResult.unwrap();
+    const importUrl = document.importUrl;
+    if (!importUrl) {
+      return {
+        success: false,
+        error: "Document was not imported from a URL and cannot be re-uploaded",
+      };
+    }
+
+    // Process the article again from the importUrl
+    const processedArticle = await processArticle(importUrl);
+
+    // Update the document with the new content
+    const updateResult = await documentService.updateDocument(
+      docId,
+      session.user.id,
+      {
+        title: processedArticle.title,
+        content: processedArticle.content,
+      }
+    );
+
+    if (updateResult.isError()) {
+      const error = updateResult.error();
+      return {
+        success: false,
+        error: error?.message || "Failed to update document",
+      };
+    }
+
+    // Revalidate the document paths
+    revalidatePath(`/docs/${docId}/reader`);
+    revalidatePath(`/docs/${docId}`);
+
+    return { success: true };
+  } catch (error) {
+    logger.error('Error re-uploading document:', error);
+    return { 
+      success: false, 
+      error: error instanceof Error ? error.message : "Failed to re-upload document" 
+    };
+  }
+}

--- a/apps/web/src/app/explore/[docId]/reader/page.tsx
+++ b/apps/web/src/app/explore/[docId]/reader/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { DocumentWithEvaluations } from "@/components/DocumentWithEvaluations";
+import { auth } from "@/infrastructure/auth/auth";
+import { DocumentModel } from "@/models/Document";
+
+export default async function DocumentPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ docId: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const resolvedParams = await params;
+  const resolvedSearchParams = await searchParams;
+  const docId = resolvedParams.docId;
+  const session = await auth();
+  const currentUserId = session?.user?.id;
+
+  // Validate docId
+  if (!docId) {
+    notFound();
+  }
+
+  const document = await DocumentModel.getDocumentForReader(docId);
+
+  if (!document) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-white p-4">
+        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          Document not found
+        </h1>
+        <p className="mb-8 text-gray-600">
+          The document you're looking for doesn't exist or has been moved.
+        </p>
+        <Link
+          href="/docs"
+          className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Back to Documents
+        </Link>
+      </div>
+    );
+  }
+
+  // Check if current user is the owner
+  const isOwner = currentUserId
+    ? document.submittedById === currentUserId
+    : false;
+
+  // Parse evaluation filter from query params
+  const evalParam = resolvedSearchParams.evals;
+  const selectedEvalIds = evalParam
+    ? Array.isArray(evalParam)
+      ? evalParam
+      : typeof evalParam === 'string'
+      ? evalParam.split(',').filter(id => id.length > 0)
+      : [evalParam]
+    : undefined;
+
+  // Parse debug parameter from query params
+  const debugParam = resolvedSearchParams.debug;
+  const showDebugComments = debugParam === 'true' || debugParam === '1';
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-gray-50">
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1">
+          <DocumentWithEvaluations 
+            document={document} 
+            isOwner={isOwner}
+            initialSelectedEvalIds={selectedEvalIds}
+            showDebugComments={showDebugComments}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/error.tsx
+++ b/apps/web/src/app/explore/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import DefaultError from "@/components/global-error";
+
+export default DefaultError;

--- a/apps/web/src/app/explore/import/actions.ts
+++ b/apps/web/src/app/explore/import/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { auth } from "@/infrastructure/auth/auth";
+import { importDocumentService } from "@/application/services/documentImport";
+import { logger } from "@/infrastructure/logging/logger";
+
+export async function importDocument(url: string, agentIds: string[] = []) {
+  try {
+    // Get the current user session
+    const session = await auth();
+    
+    if (!session?.user?.id) {
+      throw new Error("User must be logged in to import a document");
+    }
+    
+    // Use the shared import service
+    const result = await importDocumentService(url, session.user.id, agentIds);
+    
+    if (!result.success) {
+      throw new Error(result.error || "Failed to import document");
+    }
+
+    revalidatePath("/docs");
+    redirect(`/docs/${result.documentId}/reader`);
+  } catch (error) {
+    logger.error('❌ Error importing document:', error);
+    throw error;
+  }
+}

--- a/apps/web/src/app/explore/import/page.tsx
+++ b/apps/web/src/app/explore/import/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { logger } from "@/infrastructure/logging/logger";
+
+import { Button } from "@/components/Button";
+import { CheckIcon } from "@heroicons/react/24/solid";
+
+import { importDocument } from "./actions";
+
+interface Agent {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export default function ImportPage() {
+  const [url, setUrl] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
+  const [loadingAgents, setLoadingAgents] = useState(true);
+
+  // Fetch available agents
+  useEffect(() => {
+    const fetchAgents = async () => {
+      try {
+        const response = await fetch("/api/agents");
+        if (!response.ok) throw new Error("Failed to fetch agents");
+        const data = await response.json();
+        setAgents(data.agents || []);
+        // Select all agents by default
+        setSelectedAgentIds((data.agents || []).map((agent: Agent) => agent.id));
+      } catch (error) {
+        logger.error('Error fetching agents:', error);
+      } finally {
+        setLoadingAgents(false);
+      }
+    };
+    fetchAgents();
+  }, []);
+
+  const toggleAgent = (agentId: string) => {
+    setSelectedAgentIds(prev => 
+      prev.includes(agentId) 
+        ? prev.filter(id => id !== agentId)
+        : [...prev, agentId]
+    );
+  };
+
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!url.trim()) {
+      setError("Please enter a URL");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      await importDocument(url.trim(), selectedAgentIds);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to import document"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <h1 className="mb-6 text-2xl font-bold">Import Document</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="url"
+            className="block text-sm font-medium text-gray-700"
+          >
+            URL <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="url"
+            id="url"
+            name="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://example.com/article"
+            required
+            disabled={isLoading}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+
+        {/* Agent Selection */}
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Run evaluations after import
+            </label>
+          </div>
+          
+          {loadingAgents ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4">
+              {[1, 2, 3, 4].map(i => (
+                <div key={i} className="h-20 bg-gray-100 rounded-lg"></div>
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto">
+              {agents.map(agent => (
+                <label
+                  key={agent.id}
+                  className="flex items-start gap-3 p-3 rounded-lg border border-gray-100 hover:bg-gray-50 hover:border-gray-200 cursor-pointer transition-colors"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedAgentIds.includes(agent.id)}
+                    onChange={() => toggleAgent(agent.id)}
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-gray-900">{agent.name}</div>
+                    <div className="text-sm text-gray-600 mt-1">{agent.description}</div>
+                  </div>
+                  {selectedAgentIds.includes(agent.id) && (
+                    <CheckIcon className="h-5 w-5 text-blue-600 flex-shrink-0 mt-1" />
+                  )}
+                </label>
+              ))}
+            </div>
+          )}
+          
+          {selectedAgentIds.length > 0 && (
+            <p className="text-sm text-gray-600">
+              {selectedAgentIds.length} evaluation{selectedAgentIds.length !== 1 ? 's' : ''} will be queued after import
+            </p>
+          )}
+        </div>
+
+        {error && <div className="text-sm text-red-600">{error}</div>}
+
+        <Button
+          type="submit"
+          disabled={isLoading || !url.trim()}
+          className="w-full"
+        >
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2">
+              <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>
+              Importing...
+            </div>
+          ) : (
+            selectedAgentIds.length > 0 
+              ? `Import & Run ${selectedAgentIds.length} Evaluation${selectedAgentIds.length !== 1 ? 's' : ''}`
+              : "Import Document"
+          )}
+        </Button>
+      </form>
+
+      {isLoading && (
+        <div className="mt-4 text-center text-sm text-gray-600">
+          Importing may take 10-20 seconds. Please be patient while we process
+          your document.
+        </div>
+      )}
+
+      <div className="mt-6 text-sm text-gray-600">
+        <p>Supported platforms:</p>
+        <ul className="mt-2 list-inside list-disc space-y-1">
+          <li>LessWrong</li>
+          <li>EA Forum</li>
+          <li>Medium</li>
+          <li>Substack</li>
+          <li>General web articles</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/loading.tsx
+++ b/apps/web/src/app/explore/loading.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import DefaultLoading from "@/components/global-loading";
+
+export default DefaultLoading;

--- a/apps/web/src/app/explore/new/CreateDocumentForm.tsx
+++ b/apps/web/src/app/explore/new/CreateDocumentForm.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { logger } from "@/infrastructure/logging/logger";
+import Link from "next/link";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { Button } from "@/components/Button";
+import { FormField } from "@/components/FormField";
+import { AgentBadges } from "@/components/AgentBadges";
+import { 
+  LinkIcon, 
+  DocumentTextIcon,
+  CheckIcon 
+} from "@heroicons/react/24/outline";
+
+import { createDocument } from "./actions";
+import { importDocument } from "../import/actions";
+import { type DocumentInput, documentSchema, CONTENT_MIN_CHARS, CONTENT_MAX_WORDS } from "./schema";
+import { sortAgentsByBadgeStatus } from "@/shared/utils/agentSorting";
+import { useContentValidation } from "./hooks/useContentValidation";
+
+interface FormFieldConfig {
+  name: keyof DocumentInput;
+  label: string;
+  required?: boolean;
+  type: "text" | "textarea";
+  placeholder: string;
+}
+
+const formFields: FormFieldConfig[] = [
+  {
+    name: "title",
+    label: "Title",
+    required: false,
+    type: "text",
+    placeholder: "Document title (optional - will be generated if empty)",
+  },
+  {
+    name: "authors",
+    label: "Authors",
+    required: false,
+    type: "text",
+    placeholder: "Author names (comma separated, optional)",
+  },
+  {
+    name: "urls",
+    label: "URLs",
+    type: "text",
+    placeholder: "Related URLs (comma separated)",
+  },
+  {
+    name: "platforms",
+    label: "Platforms",
+    type: "text",
+    placeholder: "Platforms (e.g., LessWrong, EA Forum)",
+  },
+];
+
+interface Agent {
+  id: string;
+  name: string;
+  description: string;
+  isRecommended?: boolean;
+  isDeprecated?: boolean;
+  isSystemManaged?: boolean;
+  providesGrades?: boolean;
+}
+
+export default function CreateDocumentForm() {
+  const [mode, setMode] = useState<"import" | "manual">("import");
+  const [importUrl, setImportUrl] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  
+  // Agent selection state
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
+  const [loadingAgents, setLoadingAgents] = useState(true);
+
+  const methods = useForm<DocumentInput>({
+    resolver: zodResolver(documentSchema),
+    defaultValues: {
+      title: "",
+      authors: "",
+      content: "",
+      urls: "",
+      platforms: "",
+    },
+  });
+
+  const {
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+    watch,
+  } = methods;
+  
+  // Watch content field for real-time validation
+  const content = watch("content");
+  const { charCount, wordCount, hasMinChars, hasMaxWords } = useContentValidation(content);
+
+  // Fetch available agents
+  useEffect(() => {
+    const fetchAgents = async () => {
+      try {
+        const response = await fetch("/api/agents");
+        if (!response.ok) throw new Error("Failed to fetch agents");
+        const data = await response.json();
+        const fetchedAgents = data.agents || [];
+        
+        // Sort agents: recommended first, then regular, then deprecated
+        const sortedAgents = sortAgentsByBadgeStatus<Agent>(fetchedAgents);
+        setAgents(sortedAgents);
+        // Start with no agents selected
+        // Users can manually select which evaluations they want to run
+      } catch (error) {
+        logger.error('Error fetching agents:', error);
+      } finally {
+        setLoadingAgents(false);
+      }
+    };
+    fetchAgents();
+  }, []);
+
+  const toggleAgent = (agentId: string) => {
+    setSelectedAgentIds(prev => 
+      prev.includes(agentId) 
+        ? prev.filter(id => id !== agentId)
+        : [...prev, agentId]
+    );
+  };
+
+  const handleImport = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!importUrl.trim()) {
+      setImportError("Please enter a URL");
+      return;
+    }
+
+    try {
+      setIsImporting(true);
+      setImportError(null);
+      await importDocument(importUrl.trim(), selectedAgentIds);
+    } catch (err) {
+      setImportError(
+        err instanceof Error ? err.message : "Failed to import document"
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const onSubmit = async (data: DocumentInput) => {
+    try {
+      const result = documentSchema.parse(data);
+      await createDocument(result, selectedAgentIds);
+    } catch (error) {
+      // Ignore Next.js redirect errors
+      if (error instanceof Error && error.message === "NEXT_REDIRECT") {
+        return;
+      }
+
+      if (error instanceof z.ZodError) {
+        let hasFieldError = false;
+        error.errors.forEach((err) => {
+          const field = typeof err.path?.[0] === "string" ? (err.path[0] as keyof DocumentInput) : undefined;
+          if (field) {
+            setError(field, { message: err.message });
+            hasFieldError = true;
+          }
+        });
+        if (!hasFieldError) {
+          setError("root", { message: "Please fix the validation errors." });
+        }
+      } else {
+        logger.error('Error submitting form:', error);
+        setError("root", { message: "An unexpected error occurred" });
+      }
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="mx-auto max-w-4xl py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <div className="mb-8">
+            <h1 className="text-2xl font-semibold text-gray-900">
+              Create New Document
+            </h1>
+            <p className="mt-2 text-sm text-gray-600">
+              Import from a URL or create manually
+            </p>
+          </div>
+
+          {/* Mode Toggle */}
+          <div className="mb-8">
+            <div className="flex rounded-lg bg-gray-100 p-1">
+              <button
+                type="button"
+                onClick={() => setMode("import")}
+                className={`flex-1 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                  mode === "import"
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-600 hover:text-gray-900"
+                }`}
+              >
+                <LinkIcon className="h-4 w-4" />
+                Import via URL
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("manual")}
+                className={`flex-1 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                  mode === "manual"
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-600 hover:text-gray-900"
+                }`}
+              >
+                <DocumentTextIcon className="h-4 w-4" />
+                Submit Text
+              </button>
+            </div>
+          </div>
+
+          {mode === "import" ? (
+            // Import Mode
+            <form onSubmit={handleImport} className="space-y-6">
+              <div>
+                <label
+                  htmlFor="url"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  URL <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="url"
+                  id="url"
+                  name="url"
+                  value={importUrl}
+                  onChange={(e) => setImportUrl(e.target.value)}
+                  placeholder="https://example.com/article"
+                  required
+                  disabled={isImporting}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+
+              {/* Agent Selection */}
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">
+                    Run evaluations after import
+                  </label>
+                </div>
+                
+                {loadingAgents ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4">
+                    {[1, 2, 3, 4].map(i => (
+                      <div key={i} className="h-20 bg-gray-100 rounded-lg"></div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto">
+                    {agents.map(agent => (
+                      <label
+                        key={agent.id}
+                        className="flex items-start gap-3 p-3 rounded-lg border border-gray-100 hover:bg-gray-50 hover:border-gray-200 cursor-pointer transition-colors"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedAgentIds.includes(agent.id)}
+                          onChange={() => toggleAgent(agent.id)}
+                          className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium text-gray-900">{agent.name}</span>
+                            <AgentBadges
+                              isDeprecated={agent.isDeprecated}
+                              isRecommended={agent.isRecommended}
+                              isSystemManaged={agent.isSystemManaged}
+                              providesGrades={agent.providesGrades}
+                              size="sm"
+                            />
+                          </div>
+                          <div className="text-sm text-gray-600 mt-1">{agent.description}</div>
+                        </div>
+                        {selectedAgentIds.includes(agent.id) && (
+                          <CheckIcon className="h-5 w-5 text-blue-600 flex-shrink-0 mt-1" />
+                        )}
+                      </label>
+                    ))}
+                  </div>
+                )}
+                
+                {selectedAgentIds.length > 0 && (
+                  <p className="text-sm text-gray-600">
+                    {selectedAgentIds.length} evaluation{selectedAgentIds.length !== 1 ? 's' : ''} will be queued after import
+                  </p>
+                )}
+              </div>
+
+              {importError && (
+                <div className="rounded-md bg-red-50 p-4">
+                  <div className="text-sm text-red-700">
+                    <p className="font-medium">Import failed</p>
+                    <p className="mt-1">{importError}</p>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-3">
+                <Link href="/docs">
+                  <Button variant="secondary">Cancel</Button>
+                </Link>
+                <Button
+                  type="submit"
+                  disabled={isImporting || !importUrl.trim()}
+                >
+                  {isImporting ? (
+                    <div className="flex items-center justify-center gap-2">
+                      <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>
+                      Importing...
+                    </div>
+                  ) : (
+                    selectedAgentIds.length > 0 
+                      ? `Import & Run ${selectedAgentIds.length} Evaluation${selectedAgentIds.length !== 1 ? 's' : ''}`
+                      : "Import Document"
+                  )}
+                </Button>
+              </div>
+
+              {isImporting && (
+                <div className="mt-4 text-center text-sm text-gray-600">
+                  Importing may take 10-20 seconds. Please be patient while we process
+                  your document.
+                </div>
+              )}
+
+              <div className="mt-6 text-sm text-gray-600">
+                <p>Supported platforms:</p>
+                <ul className="mt-2 list-inside list-disc space-y-1">
+                  <li>LessWrong</li>
+                  <li>EA Forum</li>
+                  <li>Medium</li>
+                  <li>Substack</li>
+                  <li>General web articles</li>
+                </ul>
+              </div>
+            </form>
+          ) : (
+            // Manual Mode
+            <FormProvider {...methods}>
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                  name="content"
+                  label="Content"
+                  required
+                  error={errors.content}
+                >
+                  <div className="space-y-2">
+                    <textarea
+                      {...methods.register("content")}
+                      id="content"
+                      rows={15}
+                      className={`mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${errors.content ? "border-red-500" : ""}`}
+                      placeholder="Document content in Markdown format"
+                    />
+                    <div className="flex justify-between text-sm">
+                      <div className="space-x-4">
+                        <span className={`${!hasMinChars && charCount > 0 ? "text-red-600" : "text-gray-500"}`}>
+                          {charCount} characters {!hasMinChars && charCount > 0 && `(min: ${CONTENT_MIN_CHARS})`}
+                        </span>
+                        <span className={`${!hasMaxWords && wordCount > 0 ? "text-red-600" : "text-gray-500"}`}>
+                          {wordCount.toLocaleString()} words {!hasMaxWords && `(max: ${CONTENT_MAX_WORDS.toLocaleString()})`}
+                        </span>
+                      </div>
+                      {content && (
+                        <div>
+                          {!hasMinChars && (
+                            <span className="text-red-600">Need {CONTENT_MIN_CHARS - charCount} more characters</span>
+                          )}
+                          {hasMinChars && hasMaxWords && (
+                            <span className="text-green-600">✓ Valid length</span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </FormField>
+
+                {formFields.map((field) => (
+                  <FormField
+                    key={field.name}
+                    name={field.name}
+                    label={field.label}
+                    required={field.required}
+                    error={errors[field.name]}
+                  >
+                    <input
+                      {...methods.register(field.name)}
+                      type={field.type}
+                      id={field.name}
+                      className={`mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${errors[field.name] ? "border-red-500" : ""}`}
+                      placeholder={field.placeholder}
+                    />
+                  </FormField>
+                ))}
+
+                <div className="space-y-3">
+                  <h3 className="text-sm font-medium text-gray-900">
+                    Evaluations to run after creation
+                  </h3>
+                  
+                  {loadingAgents ? (
+                    <div className="flex items-center justify-center p-4">
+                      <div className="h-5 w-5 animate-spin rounded-full border-b-2 border-gray-600"></div>
+                    </div>
+                  ) : agents.length === 0 ? (
+                    <p className="text-sm text-gray-500 italic">No evaluations available</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {agents.map((agent) => (
+                        <label
+                          key={agent.id}
+                          className="flex items-start gap-3 p-3 rounded-lg border border-gray-100 hover:bg-gray-50 hover:border-gray-200 cursor-pointer transition-colors"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedAgentIds.includes(agent.id)}
+                            onChange={() => toggleAgent(agent.id)}
+                            className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-gray-900">{agent.name}</span>
+                              <AgentBadges
+                                isDeprecated={agent.isDeprecated}
+                                isRecommended={agent.isRecommended}
+                                isSystemManaged={agent.isSystemManaged}
+                                providesGrades={agent.providesGrades}
+                                size="sm"
+                              />
+                            </div>
+                            <div className="text-sm text-gray-600 mt-1">{agent.description}</div>
+                          </div>
+                          {selectedAgentIds.includes(agent.id) && (
+                            <CheckIcon className="h-5 w-5 text-blue-600 flex-shrink-0 mt-1" />
+                          )}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                  
+                  {selectedAgentIds.length > 0 && (
+                    <p className="text-sm text-gray-600">
+                      {selectedAgentIds.length} evaluation{selectedAgentIds.length !== 1 ? 's' : ''} will be queued after creation
+                    </p>
+                  )}
+                </div>
+
+                {errors.root && (
+                  <div className="rounded-md bg-red-50 p-4">
+                    <div className="flex">
+                      <div className="ml-3">
+                        <h3 className="text-sm font-medium text-red-800">
+                          Error
+                        </h3>
+                        <div className="mt-2 text-sm text-red-700">
+                          {errors.root.message}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-3">
+                  <Link href="/docs">
+                    <Button variant="secondary">Cancel</Button>
+                  </Link>
+                  <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "Saving..." : (
+                      selectedAgentIds.length > 0 
+                        ? `Save & Run ${selectedAgentIds.length} Evaluation${selectedAgentIds.length !== 1 ? 's' : ''}`
+                        : "Save Document"
+                    )}
+                  </Button>
+                </div>
+              </form>
+            </FormProvider>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/new/actions.ts
+++ b/apps/web/src/app/explore/new/actions.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { logger } from "@/infrastructure/logging/logger";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/infrastructure/auth/auth";
+import { ValidationError } from '@roast/domain';
+import { getServices } from "@/application/services/ServiceFactory";
+
+import { type DocumentInput } from "./schema";
+
+export async function createDocument(data: DocumentInput, agentIds: string[] = []) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      throw new Error("User must be logged in to create a document");
+    }
+
+    // Create the document using the new DocumentService
+    const { documentService } = getServices();
+    const result = await documentService.createDocument(
+      session.user.id,
+      {
+        title: data.title,
+        content: data.content,
+        authors: data.authors || "Unknown",
+        url: data.urls,
+        platforms: data.platforms ? [data.platforms] : [],
+        importUrl: data.importUrl
+      },
+      agentIds
+    );
+
+    if (result.isError()) {
+      const error = result.error();
+      if (error instanceof ValidationError) {
+        // Join validation errors into a single message
+        throw new Error(error.details?.join('. ') || error.message);
+      }
+      throw new Error(error?.message || "Failed to create document");
+    }
+
+    const document = result.unwrap();
+
+    // Queue evaluations if agents are selected
+    if (agentIds.length > 0) {
+      const { evaluationService } = getServices();
+      const evaluationResult = await evaluationService.createEvaluationsForDocument({
+        documentId: document.id,
+        agentIds,
+        userId: session.user.id
+      });
+
+      if (evaluationResult.isError()) {
+        logger.error('Failed to create evaluations:', evaluationResult.error());
+        // Don't fail the document creation, just log the error
+      } else {
+        logger.info('Evaluations created successfully', {
+          documentId: document.id,
+          evaluationsCreated: evaluationResult.unwrap().length
+        });
+      }
+    }
+
+    revalidatePath("/docs");
+    redirect(`/docs/${document.id}/reader`);
+  } catch (error) {
+    logger.error('Error creating document:', error);
+    throw error;
+  }
+}

--- a/apps/web/src/app/explore/new/hooks/useContentValidation.ts
+++ b/apps/web/src/app/explore/new/hooks/useContentValidation.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import { CONTENT_MIN_CHARS, CONTENT_MAX_WORDS } from '../schema';
+
+export function useContentValidation(content: string | undefined) {
+  return useMemo(() => {
+    const charCount = content?.length || 0;
+    const wordCount = content?.trim() ? content.trim().split(/\s+/).length : 0;
+    
+    const hasMinChars = charCount >= CONTENT_MIN_CHARS;
+    const hasMaxWords = wordCount <= CONTENT_MAX_WORDS;
+    
+    return {
+      charCount,
+      wordCount,
+      hasMinChars,
+      hasMaxWords,
+    };
+  }, [content]);
+}

--- a/apps/web/src/app/explore/new/page.tsx
+++ b/apps/web/src/app/explore/new/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/infrastructure/auth/auth";
+import { ROUTES } from "@/constants/routes";
+import CreateDocumentForm from "./CreateDocumentForm";
+
+export default async function NewDocumentPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect(ROUTES.AUTH.SIGNIN);
+  }
+
+  return <CreateDocumentForm />;
+}

--- a/apps/web/src/app/explore/new/schema.ts
+++ b/apps/web/src/app/explore/new/schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+// Content validation constants
+export const CONTENT_MIN_CHARS = 30;
+export const CONTENT_MAX_WORDS = 50000;
+
+// Schema for form validation
+export const documentSchema = z.object({
+  title: z.string().optional(),
+  authors: z.string().optional(),
+  content: z.string()
+    .min(CONTENT_MIN_CHARS, `Content must be at least ${CONTENT_MIN_CHARS} characters`)
+    .refine((content) => {
+      // Count words (split by whitespace)
+      const trimmed = content.trim();
+      const wordCount = trimmed ? trimmed.split(/\s+/).length : 0;
+      return wordCount <= CONTENT_MAX_WORDS;
+    }, `Content must not exceed ${CONTENT_MAX_WORDS.toLocaleString()} words`),
+  urls: z.string().optional(),
+  platforms: z.string().optional(),
+  importUrl: z.string().optional(),
+});
+
+export type DocumentInput = z.infer<typeof documentSchema>;

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -1,0 +1,53 @@
+import { Suspense } from "react";
+import SearchBar from "./SearchBar";
+import DocumentsResults from "./DocumentsResults";
+import { DocumentModel } from "@/models/Document";
+import { PageLayout } from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { auth } from "@/infrastructure/auth/auth";
+
+export const dynamic = "force-dynamic";
+
+interface DocumentsPageProps {
+  searchParams: Promise<{
+    search?: string;
+  }>;
+}
+
+export default async function DocumentsPage({
+  searchParams,
+}: DocumentsPageProps) {
+  const searchQuery = (await searchParams).search || "";
+  const session = await auth();
+  const isLoggedIn = !!session?.user;
+
+  // Get documents for listing view
+  const documents = await DocumentModel.getDocumentListings({
+    searchQuery,
+    limit: 50,
+  });
+
+  const totalCount = documents.length;
+  const hasSearched = !!searchQuery.trim() && searchQuery.trim().length >= 2;
+
+  return (
+    <>
+      <SearchBar searchQuery={searchQuery} showNewButton={isLoggedIn} />
+
+      <Suspense
+        fallback={
+          <PageLayout>
+            <Skeleton className="h-full w-full" />
+          </PageLayout>
+        }
+      >
+        <DocumentsResults
+          documents={documents}
+          searchQuery={searchQuery}
+          totalCount={totalCount}
+          hasSearched={hasSearched}
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/apps/web/src/app/my-documents/page.tsx
+++ b/apps/web/src/app/my-documents/page.tsx
@@ -1,0 +1,60 @@
+import { Suspense } from "react";
+import SearchBar from "../docs/SearchBar";
+import DocumentsResults from "../docs/DocumentsResults";
+import { DocumentModel } from "@/models/Document";
+import { PageLayout } from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { auth } from "@/infrastructure/auth/auth";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+interface MyDocumentsPageProps {
+  searchParams: Promise<{
+    search?: string;
+  }>;
+}
+
+export default async function MyDocumentsPage({
+  searchParams,
+}: MyDocumentsPageProps) {
+  const session = await auth();
+  
+  // Redirect to login if not authenticated
+  if (!session?.user) {
+    redirect("/api/auth/signin");
+  }
+
+  const searchQuery = (await searchParams).search || "";
+
+  // Get only the current user's documents
+  const documents = await DocumentModel.getDocumentListings({
+    searchQuery,
+    limit: 50,
+    userId: session.user.id,
+  });
+
+  const totalCount = documents.length;
+  const hasSearched = !!searchQuery.trim() && searchQuery.trim().length >= 2;
+
+  return (
+    <>
+      <SearchBar searchQuery={searchQuery} showNewButton={true} />
+
+      <Suspense
+        fallback={
+          <PageLayout>
+            <Skeleton className="h-full w-full" />
+          </PageLayout>
+        }
+      >
+        <DocumentsResults
+          documents={documents}
+          searchQuery={searchQuery}
+          totalCount={totalCount}
+          hasSearched={hasSearched}
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -1,8 +1,6 @@
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-import { User, Pencil } from "lucide-react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { User } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { auth } from "@/infrastructure/auth/auth";
@@ -28,7 +26,7 @@ export default async function UserPage({
   return (
     <div className="mx-auto max-w-4xl p-8">
       {/* User Header */}
-      <div className="mb-8 flex items-center justify-between">
+      <div className="mb-8 flex items-center">
         <div className="flex items-center gap-4">
           <Avatar className="h-16 w-16">
             <AvatarFallback className="text-xl">
@@ -39,20 +37,8 @@ export default async function UserPage({
             <h1 className="text-2xl font-semibold">
               {user.name || USER_DISPLAY.GUEST_NAME}
             </h1>
-            {user.email && (
-              <p className="text-muted-foreground text-sm">{user.email}</p>
-            )}
           </div>
         </div>
-
-        {user.isCurrentUser && (
-          <Button asChild variant="outline" className="flex items-center gap-2">
-            <Link href="/settings/profile">
-              <Pencil className="h-4 w-4" />
-              Edit Profile
-            </Link>
-          </Button>
-        )}
       </div>
 
       {/* Stats Cards */}

--- a/apps/web/src/components/AuthHeader.tsx
+++ b/apps/web/src/components/AuthHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { User, UserCircle, FlaskConical, Settings, LogOut } from "lucide-react";
+import { User, UserCircle, Settings, LogOut, Bot } from "lucide-react";
 import { ROUTES } from "@/constants/routes";
 import {
   DropdownMenu,
@@ -52,11 +52,11 @@ export default function AuthHeader() {
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <Link
-                  href="/experiments"
+                  href={`/users/${session.user?.id}/agents`}
                   className="flex cursor-pointer items-center gap-2"
                 >
-                  <FlaskConical className="h-4 w-4" />
-                  Experiments
+                  <Bot className="h-4 w-4" />
+                  My Agents
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>

--- a/apps/web/src/components/ClientLayout.tsx
+++ b/apps/web/src/components/ClientLayout.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { Bot, FileText, Users, Wrench, Home } from "lucide-react";
+import { Bot, FileText, Users, Wrench, Home, BookOpen, Library, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
 
 import AuthHeader from "./AuthHeader";
 import Footer from "./Footer";
 import ProfileCheck from "./ProfileCheck";
+import { Button } from "./ui/button";
 
 export default function ClientLayout({
   children,
@@ -15,6 +17,8 @@ export default function ClientLayout({
 }) {
   const pathname = usePathname();
   const isReaderPage = pathname?.includes("/reader");
+  const { data: session, status } = useSession();
+  const isLoggedIn = !!session;
 
   return (
     <div className="flex h-full flex-col">
@@ -23,41 +27,56 @@ export default function ClientLayout({
       <header className="flex-shrink-0 border-b border-gray-200 bg-white px-4 py-3 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between">
           <Link
-            href="/"
+            href={isLoggedIn ? "/my-documents" : "/"}
             className="text-2xl font-bold text-gray-900 transition-colors hover:text-gray-700"
           >
             Roast My Post
           </Link>
           <div className="flex items-center justify-between space-x-6">
             <nav className="flex items-center space-x-6">
-              <Link
-                href="/docs"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <FileText className="h-5 w-5" />
-                Documents
-              </Link>
-              <Link
-                href="/agents"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <Bot className="h-5 w-5" />
-                Agents
-              </Link>
-              <Link
-                href="/users"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <Users className="h-5 w-5" />
-                Users
-              </Link>
-              <Link
-                href="/tools"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <Wrench className="h-5 w-5" />
-                Tools
-              </Link>
+              {isLoggedIn ? (
+                <>
+                  <Link
+                    href="/my-documents"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <Library className="h-5 w-5" />
+                    My Docs
+                  </Link>
+                  <Button asChild size="sm" className="bg-black hover:bg-gray-800">
+                    <Link href="/docs/new">
+                      <Plus className="h-4 w-4" />
+                      New Document
+                    </Link>
+                  </Button>
+                </>
+              ) : (
+                <Link
+                  href="/explore"
+                  className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                >
+                  <BookOpen className="h-5 w-5" />
+                  Explore
+                </Link>
+              )}
+              {!isLoggedIn && (
+                <>
+                  <Link
+                    href="/agents"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <Bot className="h-5 w-5" />
+                    Agents
+                  </Link>
+                  <Link
+                    href="/tools"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <Wrench className="h-5 w-5" />
+                    Tools
+                  </Link>
+                </>
+              )}
               <AuthHeader />
             </nav>
           </div>


### PR DESCRIPTION
## Summary
- Restructured navigation to provide different experiences for logged-in vs logged-out users
- Added personalized "My Docs" section for authenticated users
- Simplified and cleaned up the user interface

## Changes

### Navigation Updates
- **Logged-in users** now see:
  - "My Docs" - personal document library
  - "New Document" button (black, using shadcn)
  - Profile dropdown with streamlined options
- **Logged-out users** see:
  - "Explore" - browse all public documents
  - "Agents" - discover available agents
  - "Tools" - access available tools
  - Login/Signup buttons

### New Routes
- `/my-documents` - Shows only the current user's documents (requires auth)
- `/explore` - Public browsing of all documents (replaces /docs for logged-out users)

### UI Improvements
- "Roast My Post" logo now redirects to My Docs for logged-in users
- Removed "Tools" from logged-in navigation (less relevant for authenticated users)
- Removed "Experiments" from user dropdown menu
- Cleaned up user profile page by removing email address and "Edit Profile" button
- Added "My Agents" link to user dropdown for easy access

## Test plan
- [ ] Test navigation as logged-out user
- [ ] Test navigation as logged-in user
- [ ] Verify /my-documents shows only user's own documents
- [ ] Verify /explore shows all documents
- [ ] Check that profile page displays correctly without email/edit button
- [ ] Verify all navigation links work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)