### PR TITLE
feat: Streamline navigation for logged-in vs logged-out users

### DIFF
--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation";
+
+export default function ExplorePage() {
+  // For now, redirect to the existing /docs page
+  // In the future, this could be its own page with different filtering
+  redirect("/docs");
+}

--- a/apps/web/src/app/my-documents/page.tsx
+++ b/apps/web/src/app/my-documents/page.tsx
@@ -1,0 +1,60 @@
+import { Suspense } from "react";
+import SearchBar from "../docs/SearchBar";
+import DocumentsResults from "../docs/DocumentsResults";
+import { DocumentModel } from "@/models/Document";
+import { PageLayout } from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { auth } from "@/infrastructure/auth/auth";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+interface MyDocumentsPageProps {
+  searchParams: Promise<{
+    search?: string;
+  }>;
+}
+
+export default async function MyDocumentsPage({
+  searchParams,
+}: MyDocumentsPageProps) {
+  const session = await auth();
+  
+  // Redirect to login if not authenticated
+  if (!session?.user) {
+    redirect("/api/auth/signin");
+  }
+
+  const searchQuery = (await searchParams).search || "";
+
+  // Get only the current user's documents
+  const documents = await DocumentModel.getDocumentListings({
+    searchQuery,
+    limit: 50,
+    userId: session.user.id,
+  });
+
+  const totalCount = documents.length;
+  const hasSearched = !!searchQuery.trim() && searchQuery.trim().length >= 2;
+
+  return (
+    <>
+      <SearchBar searchQuery={searchQuery} showNewButton={true} />
+
+      <Suspense
+        fallback={
+          <PageLayout>
+            <Skeleton className="h-full w-full" />
+          </PageLayout>
+        }
+      >
+        <DocumentsResults
+          documents={documents}
+          searchQuery={searchQuery}
+          totalCount={totalCount}
+          hasSearched={hasSearched}
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -1,8 +1,6 @@
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-import { User, Pencil } from "lucide-react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { User } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { auth } from "@/infrastructure/auth/auth";
@@ -28,7 +26,7 @@ export default async function UserPage({
   return (
     <div className="mx-auto max-w-4xl p-8">
       {/* User Header */}
-      <div className="mb-8 flex items-center justify-between">
+      <div className="mb-8 flex items-center">
         <div className="flex items-center gap-4">
           <Avatar className="h-16 w-16">
             <AvatarFallback className="text-xl">
@@ -39,20 +37,8 @@ export default async function UserPage({
             <h1 className="text-2xl font-semibold">
               {user.name || USER_DISPLAY.GUEST_NAME}
             </h1>
-            {user.email && (
-              <p className="text-muted-foreground text-sm">{user.email}</p>
-            )}
           </div>
         </div>
-
-        {user.isCurrentUser && (
-          <Button asChild variant="outline" className="flex items-center gap-2">
-            <Link href="/settings/profile">
-              <Pencil className="h-4 w-4" />
-              Edit Profile
-            </Link>
-          </Button>
-        )}
       </div>
 
       {/* Stats Cards */}

--- a/apps/web/src/components/AuthHeader.tsx
+++ b/apps/web/src/components/AuthHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { User, UserCircle, FlaskConical, Settings, LogOut } from "lucide-react";
+import { User, UserCircle, Settings, LogOut, Bot } from "lucide-react";
 import { ROUTES } from "@/constants/routes";
 import {
   DropdownMenu,
@@ -52,11 +52,11 @@ export default function AuthHeader() {
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <Link
-                  href="/experiments"
+                  href={`/users/${session.user?.id}/agents`}
                   className="flex cursor-pointer items-center gap-2"
                 >
-                  <FlaskConical className="h-4 w-4" />
-                  Experiments
+                  <Bot className="h-4 w-4" />
+                  My Agents
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>

--- a/apps/web/src/components/ClientLayout.tsx
+++ b/apps/web/src/components/ClientLayout.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { Bot, FileText, Users, Wrench, Home } from "lucide-react";
+import { Bot, FileText, Users, Wrench, Home, BookOpen, Library, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
 
 import AuthHeader from "./AuthHeader";
 import Footer from "./Footer";
 import ProfileCheck from "./ProfileCheck";
+import { Button } from "./ui/button";
 
 export default function ClientLayout({
   children,
@@ -15,6 +17,8 @@ export default function ClientLayout({
 }) {
   const pathname = usePathname();
   const isReaderPage = pathname?.includes("/reader");
+  const { data: session } = useSession();
+  const isLoggedIn = !!session;
 
   return (
     <div className="flex h-full flex-col">
@@ -23,41 +27,54 @@ export default function ClientLayout({
       <header className="flex-shrink-0 border-b border-gray-200 bg-white px-4 py-3 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between">
           <Link
-            href="/"
+            href={isLoggedIn ? "/my-documents" : "/"}
             className="text-2xl font-bold text-gray-900 transition-colors hover:text-gray-700"
           >
             Roast My Post
           </Link>
           <div className="flex items-center justify-between space-x-6">
             <nav className="flex items-center space-x-6">
-              <Link
-                href="/docs"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <FileText className="h-5 w-5" />
-                Documents
-              </Link>
-              <Link
-                href="/agents"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <Bot className="h-5 w-5" />
-                Agents
-              </Link>
-              <Link
-                href="/users"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <Users className="h-5 w-5" />
-                Users
-              </Link>
-              <Link
-                href="/tools"
-                className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
-              >
-                <Wrench className="h-5 w-5" />
-                Tools
-              </Link>
+              {isLoggedIn ? (
+                <>
+                  <Link
+                    href="/my-documents"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <Library className="h-5 w-5" />
+                    My Docs
+                  </Link>
+                  <Button asChild size="sm" className="bg-black hover:bg-gray-800">
+                    <Link href="/docs/new">
+                      <Plus className="h-4 w-4" />
+                      New Document
+                    </Link>
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/explore"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <BookOpen className="h-5 w-5" />
+                    Explore
+                  </Link>
+                  <Link
+                    href="/agents"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <Bot className="h-5 w-5" />
+                    Agents
+                  </Link>
+                  <Link
+                    href="/tools"
+                    className="flex items-center gap-2 text-gray-600 transition-colors hover:text-gray-900"
+                  >
+                    <Wrench className="h-5 w-5" />
+                    Tools
+                  </Link>
+                </>
+              )}
               <AuthHeader />
             </nav>
           </div>


### PR DESCRIPTION
## Summary
Clean reimplementation of navigation changes without the 4000+ lines of duplicated code from PR #222.

## Changes (only ~170 lines total!)

### Navigation Updates
- **Logged-in users** see:
  - "My Docs" - personal document library  
  - "New Document" button (black, using shadcn)
  - Profile dropdown with "My Agents" link
- **Logged-out users** see:
  - "Explore" - browse all documents
  - "Agents" - discover available agents
  - "Tools" - access available tools

### Implementation Details
- `/my-documents` - Shows only the user's documents (59 lines)
- `/explore` - Simple redirect to /docs for now (6 lines)
- Navigation components updated (~100 lines of changes)
- Profile page cleaned up (removed email/Edit button)

## Why a new PR?
The previous PR #222 accidentally duplicated the entire /docs folder (4000+ lines). This clean implementation achieves the same functionality with only ~170 lines of changes.

## Test plan
- [ ] Test navigation as logged-out user
- [ ] Test navigation as logged-in user  
- [ ] Verify /my-documents shows only user's own documents
- [ ] Verify /explore redirects to /docs
- [ ] Check profile page displays correctly
- [ ] Verify all navigation links work

Closes #222

🤖 Generated with [Claude Code](https://claude.ai/code)