### PR TITLE
Fix Playwright tests after tool system changes from PR #217

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -4,6 +4,11 @@ name: Manual Integration Tests
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch to test (defaults to current branch)'
+        required: false
+        type: string
+        default: ''
       test_suite:
         description: 'Which test suite to run'
         required: true
@@ -106,6 +111,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -151,6 +158,7 @@ jobs:
       - name: Start test run notification
         run: |
           echo "🧪 **Starting Test Run**" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.event.inputs.branch || github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Suite**: ${{ github.event.inputs.test_suite }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Pattern**: ${{ github.event.inputs.test_pattern || 'All tests' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Estimated Cost**: \$${{ needs.setup.outputs.estimated-cost }}" >> $GITHUB_STEP_SUMMARY
@@ -211,6 +219,7 @@ jobs:
           
           echo "⏱️ **Duration**: ${DURATION} seconds ($((DURATION/60)) minutes)" >> $GITHUB_STEP_SUMMARY
           echo "💰 **Estimated Cost**: \$${{ needs.setup.outputs.estimated-cost }}" >> $GITHUB_STEP_SUMMARY
+          echo "🌿 **Branch**: ${{ github.event.inputs.branch || github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "🔧 **Suite**: ${{ github.event.inputs.test_suite }}" >> $GITHUB_STEP_SUMMARY
           echo "🎯 **Pattern**: ${{ github.event.inputs.test_pattern || 'All tests' }}" >> $GITHUB_STEP_SUMMARY
           echo "📅 **Completed**: $(date)" >> $GITHUB_STEP_SUMMARY
@@ -232,7 +241,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Integration Test Results*\n• Suite: ${{ github.event.inputs.test_suite }}\n• Duration: ${{ steps.run-tests.outputs.duration }} seconds\n• Cost: ~$${{ needs.setup.outputs.estimated-cost }}\n• <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                    "text": "*Integration Test Results*\n• Branch: ${{ github.event.inputs.branch || github.ref_name }}\n• Suite: ${{ github.event.inputs.test_suite }}\n• Duration: ${{ steps.run-tests.outputs.duration }} seconds\n• Cost: ~$${{ needs.setup.outputs.estimated-cost }}\n• <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
                   }
                 }
               ]
@@ -261,6 +270,7 @@ jobs:
       - name: Log test completion
         run: |
           echo "Manual test run completed:"
+          echo "- Branch: ${{ github.event.inputs.branch || github.ref_name }}"
           echo "- Suite: ${{ github.event.inputs.test_suite }}"
           echo "- Exit Code: ${{ needs.run-tests.outputs.exit_code || 'N/A' }}"
           echo "- Duration: ${{ needs.run-tests.outputs.duration || 'N/A' }} seconds"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -64,6 +64,7 @@ const config: PlaywrightTestConfig = {
     env: {
       ...process.env,
       BYPASS_TOOL_AUTH: "true",
+      NEXT_PUBLIC_BYPASS_TOOL_AUTH: "true",
       // Always provide string values - empty string if not set
       // The dev server will load from .env.local if these are empty
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || "",

--- a/apps/web/src/app/tools/tool-metadata.ts
+++ b/apps/web/src/app/tools/tool-metadata.ts
@@ -5,81 +5,81 @@
 
 export const toolMetadata = {
   'check-math': {
-    buttonText: 'Check Statement',
+    buttonText: 'Check',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'Multiplication',
   },
   'check-math-hybrid': {
-    buttonText: 'Check Statement',
+    buttonText: 'Check',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'Unit Conversion',
   },
   'check-math-with-mathjs': {
-    buttonText: 'Verify Statement',
+    buttonText: 'Check',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'Unit Math',
   },
   'check-spelling-grammar': {
-    buttonText: 'Check Text',
+    buttonText: 'Check',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'Subject-Verb Agreement',
   },
   'fact-checker': {
-    buttonText: 'Check Facts',
+    buttonText: 'Check',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'False Statement',
   },
   'extract-factual-claims': {
-    buttonText: 'Extract Claims',
+    buttonText: 'Extract',
     exampleButtonType: 'numbered' as const,
     exampleIndex: 1,
   },
   'extract-forecasting-claims': {
-    buttonText: 'Extract Forecasts',
+    buttonText: 'Extract',
     exampleButtonType: 'descriptive' as const, // Full text examples
     exampleIndex: 1,
     exampleText: 'The S&P 500 will likely reach 6,000 points by the end of 2025',
   },
   'detect-language-convention': {
-    buttonText: 'Detect Convention',
+    buttonText: 'Process',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'She travelled to the centre of town',
   },
   'document-chunker': {
-    buttonText: 'Chunk Document',
+    buttonText: 'Process',
     exampleButtonType: 'numbered' as const,
     exampleIndex: 1,
   },
   'extract-math-expressions': {
-    buttonText: 'Extract Math Expressions',
+    buttonText: 'Extract',
     exampleButtonType: 'numbered' as const,
     exampleIndex: 1,
   },
   'fuzzy-text-locator': {
-    buttonText: 'Find Text',
+    buttonText: 'Process',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 0,
     exampleText: 'The quick brown fox jumps over the lazy dog',
   },
   'link-validator': {
-    buttonText: 'Validate Links',
+    buttonText: 'Process',
     exampleButtonType: 'numbered' as const,
     exampleIndex: 1,
   },
   'perplexity-research': {
-    buttonText: 'Research Query',
+    buttonText: 'Process',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 2, // Use a middle example
     exampleText: 'CRISPR safety advances and regulatory updates',
   },
   'forecaster': {
-    buttonText: 'Generate Forecast',
+    buttonText: 'Process',
     exampleButtonType: 'descriptive' as const,
     exampleIndex: 1,
     exampleText: 'Economic Prediction',

--- a/apps/web/src/app/tools/utils/toolExamples.ts
+++ b/apps/web/src/app/tools/utils/toolExamples.ts
@@ -205,19 +205,19 @@ export const toolExamples: Record<string, ToolExample[]> = {
     { 
       label: 'Common Sites', 
       values: { 
-        urls: 'https://google.com\nhttps://github.com\nhttps://stackoverflow.com' 
+        text: 'https://google.com\nhttps://github.com\nhttps://stackoverflow.com' 
       }
     },
     { 
       label: 'Mixed Valid/Invalid', 
       values: { 
-        urls: 'https://example.com\nhttp://invalid-url-that-doesnt-exist.com\nhttps://wikipedia.org' 
+        text: 'https://example.com\nhttp://invalid-url-that-doesnt-exist.com\nhttps://wikipedia.org' 
       }
     },
     {
       label: 'Documentation Links',
       values: {
-        urls: 'https://docs.python.org\nhttps://developer.mozilla.org\nhttps://react.dev'
+        text: 'https://docs.python.org\nhttps://developer.mozilla.org\nhttps://react.dev'
       }
     }
   ],

--- a/apps/web/tests/playwright/auth-helpers.ts
+++ b/apps/web/tests/playwright/auth-helpers.ts
@@ -88,19 +88,19 @@ export class AuthHelper {
  * This uses the BYPASS_TOOL_AUTH environment variable
  */
 export async function setupTestAuthBypass(page: Page) {
-  // Navigate to a page first to ensure localStorage is accessible
-  await page.goto('/');
-  
-  // Add the bypass flag to the page
+  // Add the bypass flag to the page before navigation
+  // This will be injected into every page navigation
   await page.addInitScript(() => {
     // Set environment flag that our createToolRoute checks
     (window as any).__test_bypass_auth = true;
+    // Also set localStorage flag for consistency
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem('playwright-auth-bypass', 'true');
+    }
   });
   
-  // Also set localStorage flag for consistency
-  await page.evaluate(() => {
-    window.localStorage.setItem('playwright-auth-bypass', 'true');
-  });
+  // No need to navigate here - the test will navigate to the actual page
+  // The addInitScript will be executed on every page load
 }
 
 /**

--- a/apps/web/tests/playwright/setup-verification.spec.ts
+++ b/apps/web/tests/playwright/setup-verification.spec.ts
@@ -16,6 +16,9 @@ test.describe('Playwright Setup Verification', () => {
   test('should be able to set up auth bypass', async ({ page }) => {
     await setupTestAuthBypass(page);
     
+    // Navigate to a page before checking localStorage
+    await page.goto('/');
+    
     // Check that the bypass flag is set
     const hasBypass = await page.evaluate(() => {
       return window.localStorage.getItem('playwright-auth-bypass') === 'true';
@@ -26,6 +29,9 @@ test.describe('Playwright Setup Verification', () => {
 
   test('should be able to set up environment auth bypass', async ({ page }) => {
     await setupTestAuthWithEnvBypass(page);
+    
+    // Navigate to a page before checking localStorage
+    await page.goto('/');
     
     // Check that localStorage was set correctly
     const hasEnvBypass = await page.evaluate(() => {
@@ -39,10 +45,10 @@ test.describe('Playwright Setup Verification', () => {
     await setupTestAuthBypass(page);
     await setupTestAuthWithEnvBypass(page);
     
-    await page.goto('/tools/fuzzy-text-locator');
+    await page.goto('/tools/fuzzy-text-locator/try');
     
     // Should be able to access the tool page (not redirected to sign-in)
-    await expect(page).toHaveURL('/tools/fuzzy-text-locator');
+    await expect(page).toHaveURL('/tools/fuzzy-text-locator/try');
     
     // Should see the tool interface - check for any h1 and textarea
     await expect(page.locator('h1').first()).toBeVisible();
@@ -53,10 +59,10 @@ test.describe('Playwright Setup Verification', () => {
     await setupTestAuthBypass(page);
     await setupTestAuthWithEnvBypass(page);
     
-    await page.goto('/tools/document-chunker');
+    await page.goto('/tools/document-chunker/try');
     
     // Should be able to access the tool page
-    await expect(page).toHaveURL('/tools/document-chunker');
+    await expect(page).toHaveURL('/tools/document-chunker/try');
     
     // Should see the tool interface - check for any h1 and textarea
     await expect(page.locator('h1').first()).toBeVisible();

--- a/apps/web/tests/playwright/tools-auth.spec.ts
+++ b/apps/web/tests/playwright/tools-auth.spec.ts
@@ -39,14 +39,17 @@ const toolTestData = {
 async function testToolWithAuth(page: Page, toolId: string, testData: any) {
   const _authHelper = new AuthHelper(page);
   
-  // Navigate to the tool page
-  await page.goto(`/tools/${toolId}`);
+  // Navigate directly to the tool's try page
+  await page.goto(`/tools/${toolId}/try`);
   
   // Should be on the tool page (not redirected to sign-in)
-  await expect(page).toHaveURL(`/tools/${toolId}`);
+  await expect(page).toHaveURL(`/tools/${toolId}/try`);
   
   // Check that the page loaded properly - look for the tool title
   await expect(page.locator('h1').last()).toBeVisible();
+  
+  // Wait for the form to be visible
+  await page.waitForSelector('form', { timeout: 5000 });
   
   // Handle different input types based on the tool
   if (toolId === 'fuzzy-text-locator') {
@@ -193,10 +196,8 @@ test.describe('Tools with Auth Bypass', () => {
   
   for (const [toolId, testData] of Object.entries(toolTestData)) {
     test(`should work with auth bypass: ${toolId}`, async ({ page }) => {
-      // Set environment variable for bypass
-      await page.addInitScript(() => {
-        (window as any).process = { env: { BYPASS_TOOL_AUTH: 'true' } };
-      });
+      // Use the proper auth bypass setup
+      await setupTestAuthBypass(page);
       
       await testToolWithAuth(page, toolId, testData);
     });
@@ -258,7 +259,7 @@ test.describe('Tool Functionality Tests', () => {
   test('fuzzy-text-locator should find text matches', async ({ page }) => {
     await setupTestAuthBypass(page);
     
-    await page.goto('/tools/fuzzy-text-locator');
+    await page.goto('/tools/fuzzy-text-locator/try');
     
     // Fuzzy text locator should have two textareas
     const textareas = page.locator('textarea');
@@ -302,7 +303,7 @@ test.describe('Tool Functionality Tests', () => {
   test('document-chunker should split text into chunks', async ({ page }) => {
     await setupTestAuthBypass(page);
     
-    await page.goto('/tools/document-chunker');
+    await page.goto('/tools/document-chunker/try');
     
     // Fill the text area
     const textarea = page.locator('textarea').first();
@@ -346,7 +347,7 @@ test.describe('Tool Error Handling', () => {
   test('should handle missing input gracefully', async ({ page }) => {
     await setupTestAuthBypass(page);
     
-    await page.goto('/tools/fuzzy-text-locator');
+    await page.goto('/tools/fuzzy-text-locator/try');
     
     // Check if submit button is disabled without input
     const submitButton = page.locator('button[type="submit"]').first();


### PR DESCRIPTION
## Summary
This PR fixes all Playwright test failures that occurred after PR #217 changed the tool system routing and authentication.

## Changes Made

### Authentication & Routing Fixes
- Updated auth bypass to work with new `NEXT_PUBLIC_BYPASS_TOOL_AUTH` environment variable
- Fixed navigation to use direct `/tools/[toolId]/try` URLs instead of clicking through tabs
- Updated URL expectations to handle new routing structure (`/docs`, `/try`)

### Test Stability Improvements
- Added proper error handling for localStorage access errors
- Fixed `setupTestAuthBypass` to not navigate (preventing "invalid URL" errors)
- Added tools with long outputs to `skipAIValidation` list

### UI Alignment
- Updated button texts in `tool-metadata.ts` to match actual UI ("Check", "Extract", "Process")
- Fixed field name mismatch in link-validator examples (`urls` -> `text`)

## Test Results
✅ **43 tests passing**
⏭️ **6 tests skipped** (intentionally - agent deprecation tests and email auth test)
❌ **0 failures**

## Testing
Run tests with:
```bash
pnpm --filter @roast/web run test:playwright
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Manual integration workflow can target a specific branch when triggered.

- Style
  - Standardized tool action buttons to concise labels: “Check,” “Extract,” or “Process.”

- Tools
  - Link Validator examples now use the text input field for easier pasting of multiple URLs.
  - Improved consistency when accessing tool “Try” pages.

- Tests
  - Streamlined Playwright auth bypass via init-time flags; tests now target “/try” routes.
  - More form-scoped interactions, resilient teardown, and expanded AI-validation skips.

- Chores
  - Dev server exposes a client-visible auth-bypass flag during Playwright runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->