### PR TITLE
Improve document pages layout and card interactions

### DIFF
--- a/apps/web/src/app/docs/DocumentsResults.tsx
+++ b/apps/web/src/app/docs/DocumentsResults.tsx
@@ -1,28 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { PageLayout } from "@/components/PageLayout";
 import { GradeBadge } from "@/components/GradeBadge";
 import { PrivacyBadge } from "@/components/PrivacyBadge";
 import {
   formatWordCount,
   getWordCountInfo,
 } from "@/shared/utils/ui/documentUtils";
-import {
-  ChatBubbleLeftIcon,
-  Squares2X2Icon,
-  TableCellsIcon,
-} from "@heroicons/react/24/outline";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ChatBubbleLeftIcon } from "@heroicons/react/24/outline";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import type { SerializedDocumentListing } from "@/models/DocumentListing.types";
 
 interface DocumentsResultsProps {
@@ -42,26 +28,15 @@ export default function DocumentsResults({
   pageTitle = "Public Documents",
   showPrivacyBadges = false,
 }: DocumentsResultsProps) {
-  // Get unique evaluator names from all documents
-  const evaluators = Array.from(
-    new Set(
-      documents
-        .flatMap(
-          (doc) =>
-            doc.document?.evaluations?.map(
-              (evaluation) => evaluation.agent.name
-            ) || []
-        )
-        .filter(Boolean)
-    )
-  );
 
   return (
-    <PageLayout>
+    <>
       {/* Page Header */}
-      <div className="mb-6 text-center">
-        <h1 className="text-2xl font-semibold text-gray-900">{pageTitle}</h1>
-      </div>
+      {pageTitle && (
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-semibold text-gray-900">{pageTitle}</h1>
+        </div>
+      )}
 
       {/* Status message */}
       {!hasSearched && (
@@ -78,29 +53,9 @@ export default function DocumentsResults({
       )}
 
       {/* Content Section */}
-      <Tabs defaultValue="cards" className="w-full">
-        <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
-          <div className="px-4 sm:px-0">
-            <div className="mb-6 flex justify-center">
-              <TabsList>
-                <TabsTrigger value="cards" className="flex items-center gap-2">
-                  <Squares2X2Icon className="h-5 w-5" />
-                  Card View
-                </TabsTrigger>
-                <TabsTrigger value="table" className="flex items-center gap-2">
-                  <TableCellsIcon className="h-5 w-5" />
-                  Table View
-                </TabsTrigger>
-              </TabsList>
-            </div>
-          </div>
-        </div>
-
-        <TabsContent value="cards" className="mt-0">
-          {/* Card View - Keep in container */}
-          <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
-            <div className="px-4 sm:px-0">
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+        <div className="px-4 sm:px-0">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 {documents.map((document) => {
                   // Count reviews by agent
                   const agentReviews =
@@ -246,119 +201,8 @@ export default function DocumentsResults({
                   );
                 })}
               </div>
-            </div>
-          </div>
-        </TabsContent>
-
-        <TabsContent value="table" className="mt-0">
-          {/* Table View - Full width */}
-          <div className="w-full px-4 sm:px-6 lg:px-8">
-            <div className="overflow-x-auto">
-              <div className="min-w-[1200px] px-8">
-                {/* Minimum width to prevent squishing */}
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="max-w-[300px]">Title</TableHead>
-                      <TableHead className="w-32">Author</TableHead>
-                      <TableHead className="w-32">Date</TableHead>
-                      <TableHead className="w-48">Platforms</TableHead>
-                      <TableHead className="w-32">Length</TableHead>
-                      {evaluators.map((evaluator) => (
-                        <TableHead key={evaluator}>{evaluator}</TableHead>
-                      ))}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {documents.map((document) => (
-                      <TableRow key={document.id}>
-                        <TableCell className="max-w-[300px]">
-                          <Link
-                            href={`/docs/${document.document.id}/reader`}
-                            className="flex items-center gap-2 truncate text-blue-600 hover:text-blue-900"
-                          >
-                            {document.title}
-                            {showPrivacyBadges && (
-                              <PrivacyBadge isPrivate={document.document.isPrivate} size="xs" />
-                            )}
-                          </Link>
-                        </TableCell>
-                        <TableCell className="w-32">
-                          {document.authors.join(", ")}
-                        </TableCell>
-                        <TableCell className="w-32">
-                          {new Date(
-                            document.document.publishedDate
-                          ).toLocaleDateString("en-US", {
-                            month: "short",
-                            day: "numeric",
-                            year: "numeric",
-                          })}
-                        </TableCell>
-                        <TableCell className="w-48">
-                          <div className="flex flex-wrap gap-2">
-                            {document.platforms?.map((platform: string) => (
-                              <span
-                                key={platform}
-                                className="inline-flex items-center text-xs font-medium text-blue-500"
-                              >
-                                {platform}
-                              </span>
-                            ))}
-                          </div>
-                        </TableCell>
-                        <TableCell className="w-32">
-                          <div className="flex items-center gap-1">
-                            {(() => {
-                              const { wordCount, color } = getWordCountInfo(
-                                document.content
-                              );
-                              return (
-                                <span className={color}>
-                                  {formatWordCount(wordCount) + " words"}
-                                </span>
-                              );
-                            })()}
-                          </div>
-                        </TableCell>
-                        {evaluators.map((evaluator) => {
-                          const evaluation =
-                            document.document?.evaluations?.find(
-                              (r) => r.agent.name === evaluator
-                            );
-                          return (
-                            <TableCell key={evaluator}>
-                              {evaluation?.latestVersion?.grade !== undefined && (
-                                <GradeBadge
-                                  grade={
-                                    evaluation.latestVersion.grade as
-                                      | number
-                                      | null
-                                  }
-                                  className="text-xs"
-                                  variant="dark"
-                                />
-                              )}
-                              {evaluation && (
-                                <span className="ml-2 text-gray-500">
-                                  <ChatBubbleLeftIcon className="inline h-3 w-3 text-gray-400" />
-                                  <span className="ml-1">
-                                    {evaluation.latestVersion?.commentCount || 0}
-                                  </span>
-                                </span>
-                              )}
-                            </TableCell>
-                          );
-                        })}
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          </div>
-        </TabsContent>
-      </Tabs>
-    </PageLayout>
+        </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1,10 +1,5 @@
-import { Suspense } from "react";
-import SearchBar from "./SearchBar";
-import DocumentsResults from "./DocumentsResults";
+import DocumentsLayoutClient from "@/components/DocumentsLayoutClient";
 import { DocumentModel } from "@/models/Document";
-import { PageLayout } from "@/components/PageLayout";
-import { Skeleton } from "@/components/ui/skeleton";
-import { auth } from "@/infrastructure/auth/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -18,8 +13,6 @@ export default async function DocumentsPage({
   searchParams,
 }: DocumentsPageProps) {
   const searchQuery = (await searchParams).search || "";
-  const session = await auth();
-  const isLoggedIn = !!session?.user;
 
   // Get only public documents for the public docs page
   const documents = await DocumentModel.getDocumentListings({
@@ -32,23 +25,14 @@ export default async function DocumentsPage({
   const hasSearched = !!searchQuery.trim() && searchQuery.trim().length >= 2;
 
   return (
-    <>
-      <SearchBar searchQuery={searchQuery} showNewButton={false} />
-
-      <Suspense
-        fallback={
-          <PageLayout>
-            <Skeleton className="h-full w-full" />
-          </PageLayout>
-        }
-      >
-        <DocumentsResults
-          documents={documents}
-          searchQuery={searchQuery}
-          totalCount={totalCount}
-          hasSearched={hasSearched}
-        />
-      </Suspense>
-    </>
+    <DocumentsLayoutClient
+      documents={documents}
+      searchQuery={searchQuery}
+      totalCount={totalCount}
+      hasSearched={hasSearched}
+      title="Public Documents"
+      subtitle="Explore and review community documents"
+      showPrivacyBadges={false}
+    />
   );
 }

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1,5 +1,6 @@
 import DocumentsLayoutClient from "@/components/DocumentsLayoutClient";
 import { DocumentModel } from "@/models/Document";
+import { auth } from "@/infrastructure/auth/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,7 @@ interface DocumentsPageProps {
 export default async function DocumentsPage({
   searchParams,
 }: DocumentsPageProps) {
+  const session = await auth();
   const searchQuery = (await searchParams).search || "";
 
   // Get only public documents for the public docs page
@@ -33,6 +35,7 @@ export default async function DocumentsPage({
       title="Public Documents"
       subtitle="Explore and review community documents"
       showPrivacyBadges={false}
+      currentUserId={session?.user?.id}
     />
   );
 }

--- a/apps/web/src/app/my-documents/page.tsx
+++ b/apps/web/src/app/my-documents/page.tsx
@@ -1,9 +1,5 @@
-import { Suspense } from "react";
-import SearchBar from "../docs/SearchBar";
-import DocumentsResults from "../docs/DocumentsResults";
+import DocumentsLayoutClient from "@/components/DocumentsLayoutClient";
 import { DocumentModel } from "@/models/Document";
-import { PageLayout } from "@/components/PageLayout";
-import { Skeleton } from "@/components/ui/skeleton";
 import { auth } from "@/infrastructure/auth/auth";
 import { redirect } from "next/navigation";
 
@@ -39,25 +35,14 @@ export default async function MyDocumentsPage({
   const hasSearched = !!searchQuery.trim() && searchQuery.trim().length >= 2;
 
   return (
-    <>
-      <SearchBar searchQuery={searchQuery} showNewButton={false} />
-
-      <Suspense
-        fallback={
-          <PageLayout>
-            <Skeleton className="h-full w-full" />
-          </PageLayout>
-        }
-      >
-        <DocumentsResults
-          documents={documents}
-          searchQuery={searchQuery}
-          totalCount={totalCount}
-          hasSearched={hasSearched}
-          pageTitle="Your Documents"
-          showPrivacyBadges={true}
-        />
-      </Suspense>
-    </>
+    <DocumentsLayoutClient
+      documents={documents}
+      searchQuery={searchQuery}
+      totalCount={totalCount}
+      hasSearched={hasSearched}
+      title="Your Documents"
+      subtitle="Manage and review your uploaded documents"
+      showPrivacyBadges={true}
+    />
   );
 }

--- a/apps/web/src/app/my-documents/page.tsx
+++ b/apps/web/src/app/my-documents/page.tsx
@@ -43,6 +43,7 @@ export default async function MyDocumentsPage({
       title="Your Documents"
       subtitle="Manage and review your uploaded documents"
       showPrivacyBadges={true}
+      currentUserId={session.user.id}
     />
   );
 }

--- a/apps/web/src/components/DocumentsLayoutClient.tsx
+++ b/apps/web/src/components/DocumentsLayoutClient.tsx
@@ -14,8 +14,19 @@ import {
 import {
   ChatBubbleLeftIcon,
   MagnifyingGlassIcon,
+  EllipsisVerticalIcon,
+  PencilIcon,
+  DocumentTextIcon,
+  LinkIcon,
 } from "@heroicons/react/24/outline";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { SerializedDocumentListing } from "@/models/DocumentListing.types";
 
 interface DocumentsLayoutClientProps {
@@ -26,6 +37,7 @@ interface DocumentsLayoutClientProps {
   title: string;
   subtitle: string;
   showPrivacyBadges?: boolean;
+  currentUserId?: string;
 }
 
 export default function DocumentsLayoutClient({
@@ -36,6 +48,7 @@ export default function DocumentsLayoutClient({
   title,
   subtitle,
   showPrivacyBadges = false,
+  currentUserId,
 }: DocumentsLayoutClientProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -121,16 +134,20 @@ export default function DocumentsLayoutClient({
                 {} as Record<string, number>
               ) || {};
 
+            const isOwner = currentUserId && document.document.submittedById === currentUserId;
+            const hasSource = document.urls && document.urls.length > 0;
+
             return (
-              <Link
-                key={document.id}
-                href={`/docs/${document.document.id}/reader`}
-                className="block"
-              >
-                <Card className="h-full cursor-pointer transition-colors duration-150 hover:bg-gray-50">
-                  <CardHeader className="pb-3">
+              <div key={document.id} className="relative">
+                <Card className="h-full transition-colors duration-150">
+                  <CardHeader className="pb-3 pr-12">
                     <CardTitle className="text-base leading-7">
-                      {document.title}
+                      <Link 
+                        href={`/docs/${document.document.id}/reader`}
+                        className="hover:text-blue-600 transition-colors"
+                      >
+                        {document.title}
+                      </Link>
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="pt-0">
@@ -219,9 +236,10 @@ export default function DocumentsLayoutClient({
                           const grade = evaluation?.latestVersion?.grade;
 
                           return (
-                            <div
+                            <Link
                               key={agentId}
-                              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
+                              href={`/docs/${document.document.id}/reader?evals=${agentId}`}
+                              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 hover:bg-gray-200 transition-colors"
                             >
                               {evaluation?.agent.name || "Unknown Agent"}
                               {hasGrade && (
@@ -235,7 +253,7 @@ export default function DocumentsLayoutClient({
                               <span className="text-gray-500">
                                 {commentCount}
                               </span>
-                            </div>
+                            </Link>
                           );
                         }
                       )}
@@ -247,7 +265,53 @@ export default function DocumentsLayoutClient({
                     </div>
                   </CardContent>
                 </Card>
-              </Link>
+                
+                {/* Dropdown Menu */}
+              <div className="absolute top-2 right-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="p-1.5 rounded-md hover:bg-gray-100 transition-colors"
+                      onClick={(e) => e.preventDefault()}
+                    >
+                      <EllipsisVerticalIcon className="h-5 w-5 text-gray-500" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-48">
+                    {isOwner && (
+                      <>
+                        <DropdownMenuItem asChild>
+                          <a href={`/docs/${document.document.id}/edit`} className="flex items-center gap-2 cursor-pointer">
+                            <PencilIcon className="h-4 w-4" />
+                            <span>Edit</span>
+                          </a>
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                      </>
+                    )}
+                    <DropdownMenuItem asChild>
+                      <a href={`/docs/${document.document.id}`} className="flex items-center gap-2 cursor-pointer">
+                        <DocumentTextIcon className="h-4 w-4" />
+                        <span>Details</span>
+                      </a>
+                    </DropdownMenuItem>
+                    {hasSource && (
+                      <DropdownMenuItem asChild>
+                        <a 
+                          href={document.urls[0]} 
+                          target="_blank" 
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-2 cursor-pointer"
+                        >
+                          <LinkIcon className="h-4 w-4" />
+                          <span>Source</span>
+                        </a>
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
             );
           })}
         </div>

--- a/apps/web/src/components/DocumentsLayoutClient.tsx
+++ b/apps/web/src/components/DocumentsLayoutClient.tsx
@@ -75,8 +75,12 @@ export default function DocumentsLayoutClient({
   }, [initialSearchQuery]);
 
   // Debounced search function that updates URL
-  const debouncedSearch = useDebouncedCallback((query: string) => {
-    const params = new URLSearchParams(searchParams.toString());
+  const debouncedSearch = useDebouncedCallback((
+    query: string,
+    currentSearchParams: ReadonlyURLSearchParams,
+    currentPathname: string
+  ) => {
+    const params = new URLSearchParams(currentSearchParams.toString());
 
     if (query.trim()) {
       params.set("search", query.trim());
@@ -85,16 +89,16 @@ export default function DocumentsLayoutClient({
     }
 
     const newUrl = params.toString()
-      ? `${pathname}?${params.toString()}`
-      : pathname;
-    router.push(newUrl);
+      ? `${currentPathname}?${params.toString()}`
+      : currentPathname;
+    router.replace(newUrl, { scroll: false });
   }, 300);
 
   // Handle search input change
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchQuery(value);
-    debouncedSearch(value);
+    debouncedSearch(value, searchParams, pathname);
   };
 
   return (
@@ -227,7 +231,7 @@ export default function DocumentsLayoutClient({
                                 {document.platforms.map((platform: string) => (
                                   <span
                                     key={platform}
-                                    className="inline-flex items-center text-xs font-medium text-gray-500"
+                                    className="inline-flex items-center text-xs font-medium text-blue-500"
                                   >
                                     {platform}
                                   </span>

--- a/apps/web/src/components/DocumentsLayoutClient.tsx
+++ b/apps/web/src/components/DocumentsLayoutClient.tsx
@@ -35,6 +35,7 @@ import {
   getWordCountInfo,
 } from "@/shared/utils/ui/documentUtils";
 import {
+  BookOpenIcon,
   ChatBubbleLeftIcon,
   DocumentTextIcon,
   EllipsisVerticalIcon,
@@ -75,24 +76,27 @@ export default function DocumentsLayoutClient({
   }, [initialSearchQuery]);
 
   // Debounced search function that updates URL
-  const debouncedSearch = useDebouncedCallback((
-    query: string,
-    currentSearchParams: ReadonlyURLSearchParams,
-    currentPathname: string
-  ) => {
-    const params = new URLSearchParams(currentSearchParams.toString());
+  const debouncedSearch = useDebouncedCallback(
+    (
+      query: string,
+      currentSearchParams: URLSearchParams,
+      currentPathname: string
+    ) => {
+      const params = new URLSearchParams(currentSearchParams.toString());
 
-    if (query.trim()) {
-      params.set("search", query.trim());
-    } else {
-      params.delete("search");
-    }
+      if (query.trim()) {
+        params.set("search", query.trim());
+      } else {
+        params.delete("search");
+      }
 
-    const newUrl = params.toString()
-      ? `${currentPathname}?${params.toString()}`
-      : currentPathname;
-    router.replace(newUrl, { scroll: false });
-  }, 300);
+      const newUrl = params.toString()
+        ? `${currentPathname}?${params.toString()}`
+        : currentPathname;
+      router.replace(newUrl, { scroll: false });
+    },
+    300
+  );
 
   // Handle search input change
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -161,18 +165,77 @@ export default function DocumentsLayoutClient({
             const hasSource = document.urls && document.urls.length > 0;
 
             return (
-              <div key={document.id} className="relative">
-                <Card className="h-full transition-colors duration-150">
-                  <CardHeader className="pb-3 pr-12">
+              <Card key={document.id} className="h-full">
+                <CardHeader className="pb-3">
+                  <div className="flex items-start justify-between gap-2">
                     <CardTitle className="text-base leading-7">
                       <Link
                         href={`/docs/${document.document.id}/reader`}
-                        className="transition-colors hover:text-blue-600"
+                        className="hover:underline"
                       >
                         {document.title}
                       </Link>
                     </CardTitle>
-                  </CardHeader>
+                    {/* Dropdown Menu */}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          className="rounded-md p-1.5 transition-colors hover:bg-gray-100"
+                          onClick={(e) => e.preventDefault()}
+                        >
+                          <EllipsisVerticalIcon className="h-5 w-5 text-gray-500" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-48">
+                        {isOwner && (
+                          <>
+                            <DropdownMenuItem asChild>
+                              <a
+                                href={`/docs/${document.document.id}/edit`}
+                                className="flex cursor-pointer items-center gap-2"
+                              >
+                                <PencilIcon className="h-4 w-4" />
+                                <span>Edit</span>
+                              </a>
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                          </>
+                        )}
+                        <DropdownMenuItem asChild>
+                          <a
+                            href={`/docs/${document.document.id}/reader`}
+                            className="flex cursor-pointer items-center gap-2"
+                          >
+                            <BookOpenIcon className="h-4 w-4" />
+                            <span>Reader</span>
+                          </a>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                          <a
+                            href={`/docs/${document.document.id}`}
+                            className="flex cursor-pointer items-center gap-2"
+                          >
+                            <DocumentTextIcon className="h-4 w-4" />
+                            <span>Inspector View</span>
+                          </a>
+                        </DropdownMenuItem>
+                        {hasSource && (
+                          <DropdownMenuItem asChild>
+                            <a
+                              href={document.urls[0]}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex cursor-pointer items-center gap-2"
+                            >
+                              <LinkIcon className="h-4 w-4" />
+                              <span>Source</span>
+                            </a>
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </CardHeader>
                   <CardContent className="pt-0">
                     <div className="mb-2 flex items-center gap-2 text-xs text-gray-500">
                       <div>{document.authors.join(", ")}</div>
@@ -189,16 +252,31 @@ export default function DocumentsLayoutClient({
                       <div className="text-gray-300">•</div>
                       <div className="flex items-center gap-1">
                         {(() => {
-                          const { wordCount, color } = getWordCountInfo(
+                          const { wordCount } = getWordCountInfo(
                             document.content
                           );
                           return (
-                            <span className={color}>
+                            <span className="text-gray-500">
                               {formatWordCount(wordCount) + " words"}
                             </span>
                           );
                         })()}
                       </div>
+                      {document.platforms && document.platforms.length > 0 && (
+                        <>
+                          <div className="text-gray-300">•</div>
+                          <div className="flex items-center gap-2">
+                            {document.platforms.map((platform: string) => (
+                              <span
+                                key={platform}
+                                className="inline-flex items-center text-xs font-medium text-gray-500"
+                              >
+                                {platform}
+                              </span>
+                            ))}
+                          </div>
+                        </>
+                      )}
                     </div>
                     {document.urls[0] && (
                       <div className="mb-3 flex items-center gap-2 truncate text-xs">
@@ -223,22 +301,6 @@ export default function DocumentsLayoutClient({
                             }
                           })()}
                         </span>
-                        {document.platforms &&
-                          document.platforms.length > 0 && (
-                            <>
-                              <div className="text-gray-300">•</div>
-                              <div className="flex items-center gap-2">
-                                {document.platforms.map((platform: string) => (
-                                  <span
-                                    key={platform}
-                                    className="inline-flex items-center text-xs font-medium text-blue-500"
-                                  >
-                                    {platform}
-                                  </span>
-                                ))}
-                              </div>
-                            </>
-                          )}
                       </div>
                     )}
                     <div className="mt-6 flex flex-wrap gap-2">
@@ -288,59 +350,6 @@ export default function DocumentsLayoutClient({
                     </div>
                   </CardContent>
                 </Card>
-
-                {/* Dropdown Menu */}
-                <div className="absolute right-2 top-2">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        className="rounded-md p-1.5 transition-colors hover:bg-gray-100"
-                        onClick={(e) => e.preventDefault()}
-                      >
-                        <EllipsisVerticalIcon className="h-5 w-5 text-gray-500" />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-48">
-                      {isOwner && (
-                        <>
-                          <DropdownMenuItem asChild>
-                            <a
-                              href={`/docs/${document.document.id}/edit`}
-                              className="flex cursor-pointer items-center gap-2"
-                            >
-                              <PencilIcon className="h-4 w-4" />
-                              <span>Edit</span>
-                            </a>
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                        </>
-                      )}
-                      <DropdownMenuItem asChild>
-                        <a
-                          href={`/docs/${document.document.id}`}
-                          className="flex cursor-pointer items-center gap-2"
-                        >
-                          <DocumentTextIcon className="h-4 w-4" />
-                          <span>Details</span>
-                        </a>
-                      </DropdownMenuItem>
-                      {hasSource && (
-                        <DropdownMenuItem asChild>
-                          <a
-                            href={document.urls[0]}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex cursor-pointer items-center gap-2"
-                          >
-                            <LinkIcon className="h-4 w-4" />
-                            <span>Source</span>
-                          </a>
-                        </DropdownMenuItem>
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              </div>
             );
           })}
         </div>

--- a/apps/web/src/components/DocumentsLayoutClient.tsx
+++ b/apps/web/src/components/DocumentsLayoutClient.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useDebouncedCallback } from "use-debounce";
+import Link from "next/link";
+import { PageLayout } from "@/components/PageLayout";
+import { GradeBadge } from "@/components/GradeBadge";
+import { PrivacyBadge } from "@/components/PrivacyBadge";
+import {
+  formatWordCount,
+  getWordCountInfo,
+} from "@/shared/utils/ui/documentUtils";
+import {
+  ChatBubbleLeftIcon,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/outline";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { SerializedDocumentListing } from "@/models/DocumentListing.types";
+
+interface DocumentsLayoutClientProps {
+  documents: SerializedDocumentListing[];
+  searchQuery: string;
+  totalCount: number;
+  hasSearched: boolean;
+  title: string;
+  subtitle: string;
+  showPrivacyBadges?: boolean;
+}
+
+export default function DocumentsLayoutClient({
+  documents,
+  searchQuery: initialSearchQuery,
+  totalCount,
+  hasSearched,
+  title,
+  subtitle,
+  showPrivacyBadges = false,
+}: DocumentsLayoutClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+
+  // Update local state when prop changes
+  useEffect(() => {
+    setSearchQuery(initialSearchQuery);
+  }, [initialSearchQuery]);
+
+  // Debounced search function that updates URL
+  const debouncedSearch = useDebouncedCallback((query: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (query.trim()) {
+      params.set("search", query.trim());
+    } else {
+      params.delete("search");
+    }
+
+    const newUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+    router.push(newUrl);
+  }, 300);
+
+  // Handle search input change
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchQuery(value);
+    debouncedSearch(value);
+  };
+
+  return (
+    <PageLayout background="gray">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {/* Header Section */}
+        <div className="pt-8 pb-6">
+          <h1 className="text-3xl font-semibold text-gray-900">{title}</h1>
+          <p className="mt-2 text-gray-600">{subtitle}</p>
+        </div>
+        
+        {/* Search Bar */}
+        <div className="mb-8">
+          <div className="relative max-w-2xl">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+              <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+            </div>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={handleSearchChange}
+              placeholder="Search documents..."
+              className="flex h-10 w-full rounded-md border border-gray-200 bg-white px-3 py-2 pl-10 text-sm placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            />
+          </div>
+        </div>
+
+        {/* Status message */}
+        {!hasSearched && (
+          <div className="mb-6 text-sm text-gray-600">
+            Showing {totalCount} most recent documents. Type at least 2 characters to search all documents.
+          </div>
+        )}
+
+        {hasSearched && (
+          <div className="mb-6 text-sm text-gray-600">
+            Found {totalCount} documents matching "{searchQuery}"
+          </div>
+        )}
+
+        {/* Cards Grid */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {documents.map((document) => {
+            const agentReviews =
+              document.document?.evaluations?.reduce(
+                (acc: Record<string, number>, evaluation) => {
+                  const agentId = evaluation.agentId;
+                  acc[agentId] =
+                    (acc[agentId] || 0) +
+                    (evaluation.latestVersion?.commentCount || 0);
+                  return acc;
+                },
+                {} as Record<string, number>
+              ) || {};
+
+            return (
+              <Link
+                key={document.id}
+                href={`/docs/${document.document.id}/reader`}
+                className="block"
+              >
+                <Card className="h-full cursor-pointer transition-colors duration-150 hover:bg-gray-50">
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base leading-7">
+                      {document.title}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <div className="mb-2 flex items-center gap-2 text-xs text-gray-500">
+                      <div>{document.authors.join(", ")}</div>
+                      <div className="text-gray-300">•</div>
+                      <div>
+                        {new Date(
+                          document.document.publishedDate
+                        ).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </div>
+                      <div className="text-gray-300">•</div>
+                      <div className="flex items-center gap-1">
+                        {(() => {
+                          const { wordCount, color } = getWordCountInfo(
+                            document.content
+                          );
+                          return (
+                            <span className={color}>
+                              {formatWordCount(wordCount) + " words"}
+                            </span>
+                          );
+                        })()}
+                      </div>
+                    </div>
+                    {document.urls[0] && (
+                      <div className="mb-3 flex items-center gap-2 truncate text-xs">
+                        <span
+                          className="cursor-pointer text-blue-400 hover:underline"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            window.open(
+                              document.urls[0],
+                              "_blank",
+                              "noopener,noreferrer"
+                            );
+                          }}
+                        >
+                          {(() => {
+                            try {
+                              const url = new URL(document.urls[0]);
+                              const path = url.pathname.split("/")[1];
+                              return `${url.hostname}${path ? `/${path}...` : ""}`;
+                            } catch {
+                              return document.urls[0];
+                            }
+                          })()}
+                        </span>
+                        {document.platforms &&
+                          document.platforms.length > 0 && (
+                            <>
+                              <div className="text-gray-300">•</div>
+                              <div className="flex items-center gap-2">
+                                {document.platforms.map(
+                                  (platform: string) => (
+                                    <span
+                                      key={platform}
+                                      className="inline-flex items-center text-xs font-medium text-blue-500"
+                                    >
+                                      {platform}
+                                    </span>
+                                  )
+                                )}
+                              </div>
+                            </>
+                          )}
+                      </div>
+                    )}
+                    <div className="flex flex-wrap gap-2">
+                      {showPrivacyBadges && (
+                        <PrivacyBadge isPrivate={document.document.isPrivate} size="xs" />
+                      )}
+                      {Object.entries(agentReviews).map(
+                        ([agentId, commentCount]) => {
+                          const evaluation =
+                            document.document.evaluations.find(
+                              (r) => r.agentId === agentId
+                            );
+                          const hasGrade =
+                            evaluation?.latestVersion?.grade !== null &&
+                            evaluation?.latestVersion?.grade !== undefined;
+                          const grade = evaluation?.latestVersion?.grade;
+
+                          return (
+                            <div
+                              key={agentId}
+                              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
+                            >
+                              {evaluation?.agent.name || "Unknown Agent"}
+                              {hasGrade && (
+                                <GradeBadge
+                                  grade={grade ?? null}
+                                  className="ml-1 text-xs"
+                                  variant="dark"
+                                />
+                              )}
+                              <ChatBubbleLeftIcon className="ml-2 h-3 w-3 text-gray-400" />{" "}
+                              <span className="text-gray-500">
+                                {commentCount}
+                              </span>
+                            </div>
+                          );
+                        }
+                      )}
+                      {!document.document?.evaluations?.length && (
+                        <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
+                          No reviews yet
+                        </span>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/components/DocumentsLayoutClient.tsx
+++ b/apps/web/src/components/DocumentsLayoutClient.tsx
@@ -1,25 +1,27 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { useDebouncedCallback } from "use-debounce";
+import {
+  useEffect,
+  useState,
+} from "react";
+
 import Link from "next/link";
-import { PageLayout } from "@/components/PageLayout";
+import {
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { useDebouncedCallback } from "use-debounce";
+
 import { GradeBadge } from "@/components/GradeBadge";
+import { PageLayout } from "@/components/PageLayout";
 import { PrivacyBadge } from "@/components/PrivacyBadge";
 import {
-  formatWordCount,
-  getWordCountInfo,
-} from "@/shared/utils/ui/documentUtils";
-import {
-  ChatBubbleLeftIcon,
-  MagnifyingGlassIcon,
-  EllipsisVerticalIcon,
-  PencilIcon,
-  DocumentTextIcon,
-  LinkIcon,
-} from "@heroicons/react/24/outline";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,6 +30,18 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { SerializedDocumentListing } from "@/models/DocumentListing.types";
+import {
+  formatWordCount,
+  getWordCountInfo,
+} from "@/shared/utils/ui/documentUtils";
+import {
+  ChatBubbleLeftIcon,
+  DocumentTextIcon,
+  EllipsisVerticalIcon,
+  LinkIcon,
+  MagnifyingGlassIcon,
+  PencilIcon,
+} from "@heroicons/react/24/outline";
 
 interface DocumentsLayoutClientProps {
   documents: SerializedDocumentListing[];
@@ -70,7 +84,9 @@ export default function DocumentsLayoutClient({
       params.delete("search");
     }
 
-    const newUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+    const newUrl = params.toString()
+      ? `${pathname}?${params.toString()}`
+      : pathname;
     router.push(newUrl);
   }, 300);
 
@@ -85,11 +101,11 @@ export default function DocumentsLayoutClient({
     <PageLayout background="gray">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         {/* Header Section */}
-        <div className="pt-8 pb-6">
+        <div className="pb-6 pt-8">
           <h1 className="text-3xl font-semibold text-gray-900">{title}</h1>
           <p className="mt-2 text-gray-600">{subtitle}</p>
         </div>
-        
+
         {/* Search Bar */}
         <div className="mb-8">
           <div className="relative max-w-2xl">
@@ -109,7 +125,8 @@ export default function DocumentsLayoutClient({
         {/* Status message */}
         {!hasSearched && (
           <div className="mb-6 text-sm text-gray-600">
-            Showing {totalCount} most recent documents. Type at least 2 characters to search all documents.
+            Showing {totalCount} most recent documents. Type at least 2
+            characters to search all documents.
           </div>
         )}
 
@@ -134,7 +151,9 @@ export default function DocumentsLayoutClient({
                 {} as Record<string, number>
               ) || {};
 
-            const isOwner = currentUserId && document.document.submittedById === currentUserId;
+            const isOwner =
+              currentUserId &&
+              document.document.submittedById === currentUserId;
             const hasSource = document.urls && document.urls.length > 0;
 
             return (
@@ -142,9 +161,9 @@ export default function DocumentsLayoutClient({
                 <Card className="h-full transition-colors duration-150">
                   <CardHeader className="pb-3 pr-12">
                     <CardTitle className="text-base leading-7">
-                      <Link 
+                      <Link
                         href={`/docs/${document.document.id}/reader`}
-                        className="hover:text-blue-600 transition-colors"
+                        className="transition-colors hover:text-blue-600"
                       >
                         {document.title}
                       </Link>
@@ -205,31 +224,31 @@ export default function DocumentsLayoutClient({
                             <>
                               <div className="text-gray-300">•</div>
                               <div className="flex items-center gap-2">
-                                {document.platforms.map(
-                                  (platform: string) => (
-                                    <span
-                                      key={platform}
-                                      className="inline-flex items-center text-xs font-medium text-blue-500"
-                                    >
-                                      {platform}
-                                    </span>
-                                  )
-                                )}
+                                {document.platforms.map((platform: string) => (
+                                  <span
+                                    key={platform}
+                                    className="inline-flex items-center text-xs font-medium text-gray-500"
+                                  >
+                                    {platform}
+                                  </span>
+                                ))}
                               </div>
                             </>
                           )}
                       </div>
                     )}
-                    <div className="flex flex-wrap gap-2">
+                    <div className="mt-6 flex flex-wrap gap-2">
                       {showPrivacyBadges && (
-                        <PrivacyBadge isPrivate={document.document.isPrivate} size="xs" />
+                        <PrivacyBadge
+                          isPrivate={document.document.isPrivate}
+                          size="xs"
+                        />
                       )}
                       {Object.entries(agentReviews).map(
                         ([agentId, commentCount]) => {
-                          const evaluation =
-                            document.document.evaluations.find(
-                              (r) => r.agentId === agentId
-                            );
+                          const evaluation = document.document.evaluations.find(
+                            (r) => r.agentId === agentId
+                          );
                           const hasGrade =
                             evaluation?.latestVersion?.grade !== null &&
                             evaluation?.latestVersion?.grade !== undefined;
@@ -239,7 +258,7 @@ export default function DocumentsLayoutClient({
                             <Link
                               key={agentId}
                               href={`/docs/${document.document.id}/reader?evals=${agentId}`}
-                              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 hover:bg-gray-200 transition-colors"
+                              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200"
                             >
                               {evaluation?.agent.name || "Unknown Agent"}
                               {hasGrade && (
@@ -265,53 +284,59 @@ export default function DocumentsLayoutClient({
                     </div>
                   </CardContent>
                 </Card>
-                
+
                 {/* Dropdown Menu */}
-              <div className="absolute top-2 right-2">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="p-1.5 rounded-md hover:bg-gray-100 transition-colors"
-                      onClick={(e) => e.preventDefault()}
-                    >
-                      <EllipsisVerticalIcon className="h-5 w-5 text-gray-500" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-48">
-                    {isOwner && (
-                      <>
-                        <DropdownMenuItem asChild>
-                          <a href={`/docs/${document.document.id}/edit`} className="flex items-center gap-2 cursor-pointer">
-                            <PencilIcon className="h-4 w-4" />
-                            <span>Edit</span>
-                          </a>
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                      </>
-                    )}
-                    <DropdownMenuItem asChild>
-                      <a href={`/docs/${document.document.id}`} className="flex items-center gap-2 cursor-pointer">
-                        <DocumentTextIcon className="h-4 w-4" />
-                        <span>Details</span>
-                      </a>
-                    </DropdownMenuItem>
-                    {hasSource && (
+                <div className="absolute right-2 top-2">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className="rounded-md p-1.5 transition-colors hover:bg-gray-100"
+                        onClick={(e) => e.preventDefault()}
+                      >
+                        <EllipsisVerticalIcon className="h-5 w-5 text-gray-500" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-48">
+                      {isOwner && (
+                        <>
+                          <DropdownMenuItem asChild>
+                            <a
+                              href={`/docs/${document.document.id}/edit`}
+                              className="flex cursor-pointer items-center gap-2"
+                            >
+                              <PencilIcon className="h-4 w-4" />
+                              <span>Edit</span>
+                            </a>
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                        </>
+                      )}
                       <DropdownMenuItem asChild>
-                        <a 
-                          href={document.urls[0]} 
-                          target="_blank" 
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 cursor-pointer"
+                        <a
+                          href={`/docs/${document.document.id}`}
+                          className="flex cursor-pointer items-center gap-2"
                         >
-                          <LinkIcon className="h-4 w-4" />
-                          <span>Source</span>
+                          <DocumentTextIcon className="h-4 w-4" />
+                          <span>Details</span>
                         </a>
                       </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      {hasSource && (
+                        <DropdownMenuItem asChild>
+                          <a
+                            href={document.urls[0]}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex cursor-pointer items-center gap-2"
+                          >
+                            <LinkIcon className="h-4 w-4" />
+                            <span>Source</span>
+                          </a>
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               </div>
-            </div>
             );
           })}
         </div>


### PR DESCRIPTION
### **User description**
## Summary
- Refactored document pages (/docs and /my-documents) to share a common layout component
- Updated UI to have a cleaner, more consistent design with gray background
- Added dropdown menus to document cards with contextual actions
- Improved card link behavior with targeted navigation

## Changes

### Layout Improvements
- Created shared `DocumentsLayoutClient` component used by both /docs and /my-documents pages
- Added light gray background to document pages for better visual hierarchy
- Changed from 3-column to 2-column grid layout for better readability
- Removed table/list view toggle - now only shows card view

### Card Enhancements
- Added dropdown menu (three dots) in top-right corner of each card with:
  - **Edit** - Shows only for document owners
  - **Details** - Links to document details page
  - **Source** - Shows only if document has a source URL
- Updated card interaction model:
  - Title links to reader page
  - Evaluation badges link to reader with specific eval selected (e.g., `?evals=system-math-checker`)
  - Removed full-card clickable area for more precise interactions

### Search Functionality
- Integrated functional search bar with debouncing (300ms)
- Updates URL with search query for shareable search results
- Shows status message indicating number of results

## Test Plan
- [x] Verify /docs page displays public documents correctly
- [x] Verify /my-documents page displays user's documents with privacy badges
- [x] Test search functionality updates URL and filters results
- [x] Confirm dropdown menu shows appropriate options based on ownership
- [x] Test evaluation badge links include correct query parameters
- [x] Verify responsive layout works on mobile/tablet/desktop

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored document pages to share common layout component

- Added dropdown menus to document cards with contextual actions

- Changed from 3-column to 2-column grid layout

- Removed table view, keeping only card view


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old /docs page"] --> C["DocumentsLayoutClient"]
  B["Old /my-documents page"] --> C
  C --> D["2-column card grid"]
  C --> E["Dropdown menus"]
  C --> F["Gray background"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DocumentsResults.tsx</strong><dd><code>Simplified DocumentsResults to card-only view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/docs/DocumentsResults.tsx

<ul><li>Removed table view and tabs functionality<br> <li> Simplified to only show card grid layout<br> <li> Changed from 3-column to 2-column grid<br> <li> Removed PageLayout wrapper and evaluators logic</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/230/files#diff-665bba21b1c626b7724d208982ee2c7b69c0d58d1454c00287c89e9bfc542c3a">+13/-169</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactored docs page to use shared layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/docs/page.tsx

<ul><li>Replaced custom layout with DocumentsLayoutClient component<br> <li> Removed SearchBar and DocumentsResults imports<br> <li> Simplified page structure and props passing</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/230/files#diff-029121c5c4d44203725ce7fc12dc8b93beb6133cd0d405a60e673ac06b503f98">+12/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactored my-documents page to use shared layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/my-documents/page.tsx

<ul><li>Replaced custom layout with DocumentsLayoutClient component<br> <li> Removed SearchBar and DocumentsResults imports<br> <li> Simplified page structure and props passing</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/230/files#diff-b697995a604f26cfc9463b9b3a32ecd34289ba43764a571b90d9322c1ed5e128">+11/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DocumentsLayoutClient.tsx</strong><dd><code>Added shared DocumentsLayoutClient with dropdown menus</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/DocumentsLayoutClient.tsx

<ul><li>Created new shared layout component for document pages<br> <li> Added debounced search functionality with URL updates<br> <li> Implemented dropdown menus with Edit, Details, and Source options<br> <li> Added gray background and 2-column responsive grid</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/230/files#diff-80a98dff4686e8c520cc81bea9c74af53abebe3f900f3be6d39e9cde065a43b4">+321/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New documents layout component with header (title/subtitle), debounced search (300ms) that updates the URL, and per-document agent review badges (grades + comment counts).  
  - Card actions menu: Edit (if owner), Reader, Inspector View, and open Source link.

- Improvements
  - Unified, responsive card-based grid replaces tabs/tables; safer URL preview and robust handling of missing data.  
  - Conditional page header and clearer status messages for total vs filtered results.

- Refactor
  - Public and My Documents pages now use the shared DocumentsLayout client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->