### PR TITLE
refactor: standardize plugin naming conventions

### DIFF
--- a/internal-packages/ai/src/analysis-plugins/plugins/forecast/index.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/forecast/index.ts
@@ -404,7 +404,7 @@ ${detailedReason}`;
   }
 }
 
-export class ForecastAnalyzerJob implements SimpleAnalysisPlugin {
+export class ForecastPlugin implements SimpleAnalysisPlugin {
   private documentText: string;
   private chunks: TextChunk[];
   private hasRun = false;
@@ -895,5 +895,3 @@ The analysis may still be valid, but the highlighting won't be precise.`,
   }
 }
 
-// Export ForecastAnalyzerJob as ForecastPlugin for compatibility
-export { ForecastAnalyzerJob as ForecastPlugin };

--- a/internal-packages/ai/src/analysis-plugins/plugins/math/index.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/math/index.ts
@@ -386,7 +386,7 @@ export class ExtractedMathExpression {
   }
 }
 
-export class MathAnalyzerJob implements SimpleAnalysisPlugin {
+export class MathPlugin implements SimpleAnalysisPlugin {
   private documentText: string;
   private chunks: TextChunk[];
   private hasRun = false;
@@ -1072,4 +1072,3 @@ This expression was skipped because it's ${extractedExpression.expression.comple
 }
 
 // Export MathAnalyzerJob as MathPlugin for compatibility
-export { MathAnalyzerJob as MathPlugin };

--- a/internal-packages/ai/src/analysis-plugins/plugins/math/math.llm.vtest.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/math/math.llm.vtest.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 // Vitest integration test file
-import { MathAnalyzerJob } from './index';
+import { MathPlugin } from './index';
 import { TextChunk } from '../../TextChunk';
 // Test file uses real tool integration - no mocking needed for this import
 import { extractMathExpressionsTool } from '../../../tools/extract-math-expressions';
@@ -64,7 +64,7 @@ Let's check: 1.2M × 1.15 = 1.38M ✓
       ),
     ];
 
-    const analyzer = new MathAnalyzerJob();
+    const analyzer = new MathPlugin();
     const result = await analyzer.analyze(chunks, documentText);
 
     // Verify results structure
@@ -136,7 +136,7 @@ they would get: σ = √((9+1+1+9+25)/5) = √9 = 3, which is wrong.
       ),
     ];
 
-    const analyzer = new MathAnalyzerJob();
+    const analyzer = new MathPlugin();
     const result = await analyzer.analyze(chunks, documentText);
 
     // Should identify complex calculations

--- a/internal-packages/ai/src/analysis-plugins/plugins/math/math.vtest.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/math/math.vtest.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 // Vitest test file
-import { MathAnalyzerJob } from './index';
+import { MathPlugin } from './index';
 import { TextChunk } from '../../TextChunk';
 import { extractMathExpressionsTool } from '../../../tools/extract-math-expressions';
 import { checkMathHybridTool } from '../../../tools/check-math-hybrid';
@@ -26,21 +26,21 @@ vi.mock('../../../shared/logger', () => ({
   },
 }));
 
-describe('MathAnalyzerJob', () => {
+describe('MathPlugin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe('name', () => {
     it('should return correct display name', () => {
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       expect(analyzer.name()).toBe('MATH');
     });
   });
 
   describe('promptForWhenToUse', () => {
     it('should return appropriate prompt', () => {
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       const prompt = analyzer.promptForWhenToUse();
       expect(prompt).toContain('math of any kind');
       expect(prompt).toContain('Equations and formulas');
@@ -50,7 +50,7 @@ describe('MathAnalyzerJob', () => {
 
   describe('routingExamples', () => {
     it('should provide appropriate routing examples', () => {
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       const examples = analyzer.routingExamples();
       expect(examples).toHaveLength(3);
       
@@ -113,11 +113,11 @@ describe('MathAnalyzerJob', () => {
           explanation: '2 + 2 equals 4, not 5',
           verifiedBy: 'mathjs',
           toolsUsed: ['mathjs'],
-          conciseCorrection: '5 → 4',
+          displayCorrection: '<r:replace from="5" to="4" />',
           errorDetails: {
             errorType: 'calculation',
             severity: 'major',
-            conciseCorrection: '5 → 4'
+            displayCorrection: '<r:replace from="5" to="4" />'
           }
         }))
         .mockImplementationOnce(() => Promise.resolve({
@@ -149,7 +149,7 @@ describe('MathAnalyzerJob', () => {
         }),
       ];
 
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
 
       const result = await analyzer.analyze(chunks, 'Basic math: 2 + 2 = 5\nPhysics formula: E = mc²');
 
@@ -170,7 +170,7 @@ describe('MathAnalyzerJob', () => {
         expressions: []
       }));
 
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       const chunks = [new TextChunk('No math here, just text.', 'chunk1')];
 
       const result = await analyzer.analyze(chunks, 'No math here, just text.');
@@ -185,7 +185,7 @@ describe('MathAnalyzerJob', () => {
         expressions: []
       }));
 
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       const chunks = [new TextChunk('Test', 'chunk1')];
 
       const result1 = await analyzer.analyze(chunks, 'Test');
@@ -198,7 +198,7 @@ describe('MathAnalyzerJob', () => {
 
   describe('getResults', () => {
     it('should throw error if analysis not run', () => {
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       expect(() => analyzer.getResults()).toThrow('Analysis has not been run yet');
     });
 
@@ -207,7 +207,7 @@ describe('MathAnalyzerJob', () => {
         expressions: []
       }));
 
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       const chunks = [new TextChunk('Test', 'chunk1')];
 
       const analysisResult = await analyzer.analyze(chunks, 'Test');
@@ -241,7 +241,7 @@ describe('MathAnalyzerJob', () => {
         toolsUsed: ['mathjs']
       }));
 
-      const analyzer = new MathAnalyzerJob();
+      const analyzer = new MathPlugin();
       const chunks = [Object.assign(new TextChunk('Test: 1 + 1 = 2', 'chunk1'), {
         findTextAbsolute: vi.fn().mockImplementation(() => Promise.resolve({
           startOffset: 5,

--- a/internal-packages/ai/src/analysis-plugins/plugins/spelling/index.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/spelling/index.ts
@@ -49,7 +49,7 @@ export interface SpellingErrorWithLocation {
   } | null;
 }
 
-export class SpellingAnalyzerJob implements SimpleAnalysisPlugin {
+export class SpellingPlugin implements SimpleAnalysisPlugin {
   // Property to bypass routing - spelling check should always run on all chunks
   readonly runOnAllChunks = true;
 
@@ -546,5 +546,3 @@ export class SpellingAnalyzerJob implements SimpleAnalysisPlugin {
   }
 }
 
-// Export SpellingAnalyzerJob as SpellingPlugin for compatibility
-export { SpellingAnalyzerJob as SpellingPlugin };

--- a/internal-packages/ai/src/analysis-plugins/plugins/spelling/spelling.llm.vtest.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/spelling/spelling.llm.vtest.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 // Vitest integration test file
-import { SpellingAnalyzerJob } from './index';
+import { SpellingPlugin } from './index';
 import { TextChunk } from '../../TextChunk';
 
 // Skip these tests in CI or when no API key is available
 const describeIfApiKey = process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.trim() !== '' ? describe : describe.skip;
 
-describeIfApiKey('SpellingAnalyzerJob Integration', () => {
+describeIfApiKey('SpellingPlugin Integration', () => {
   it('should analyze a document with spelling and grammar errors', async () => {
     const documentText = `
 # Document Analysis
@@ -58,7 +58,7 @@ In conclusion, always proofread you're work before submitting it.
       ),
     ];
 
-    const analyzer = new SpellingAnalyzerJob();
+    const analyzer = new SpellingPlugin();
     const result = await analyzer.analyze(chunks, documentText);
     
 
@@ -129,7 +129,7 @@ Professional writing requires attention to detail and a commitment to quality.
       ),
     ];
 
-    const analyzer = new SpellingAnalyzerJob();
+    const analyzer = new SpellingPlugin();
     const result = await analyzer.analyze(chunks, documentText);
 
     // Should find few or no errors

--- a/internal-packages/ai/src/analysis-plugins/plugins/spelling/spelling.vtest.ts
+++ b/internal-packages/ai/src/analysis-plugins/plugins/spelling/spelling.vtest.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 // Vitest test file
-import { SpellingAnalyzerJob } from './index';
+import { SpellingPlugin } from './index';
 import { TextChunk } from '../../TextChunk';
 import { checkSpellingGrammarTool } from '../../../tools/check-spelling-grammar';
 import * as conventionDetector from '../../../tools/detect-language-convention/conventionDetector';
@@ -24,7 +24,7 @@ vi.mock('../../../shared/logger', () => ({
 vi.mock('../../../tools/detect-language-convention/conventionDetector');
 vi.mock('../../../tools/check-spelling-grammar/grading');
 
-describe('SpellingAnalyzerJob', () => {
+describe('SpellingPlugin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     
@@ -62,14 +62,14 @@ describe('SpellingAnalyzerJob', () => {
 
   describe('name', () => {
     it('should return correct name', () => {
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
       expect(analyzer.name()).toBe('SPELLING');
     });
   });
 
   describe('promptForWhenToUse', () => {
     it('should return appropriate prompt', () => {
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
       const prompt = analyzer.promptForWhenToUse();
       expect(prompt).toContain('Spelling and grammar checking');
       expect(prompt).toContain('automatically runs');
@@ -78,7 +78,7 @@ describe('SpellingAnalyzerJob', () => {
 
   describe('routingExamples', () => {
     it('should provide appropriate routing examples', () => {
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
       const examples = analyzer.routingExamples();
       // runOnAllChunks = true, so no routing examples needed
       expect(examples).toHaveLength(0);
@@ -91,7 +91,6 @@ describe('SpellingAnalyzerJob', () => {
         {
           text: "thier",
           correction: "their",
-          conciseCorrection: "thier → their",
           type: 'spelling' as const,
           context: "This is thier house",
           importance: 30,
@@ -100,7 +99,6 @@ describe('SpellingAnalyzerJob', () => {
         {
           text: "dont",
           correction: "don't",
-          conciseCorrection: "dont → don't",
           type: 'grammar' as const,
           context: "They dont know",
           importance: 40,
@@ -138,7 +136,7 @@ describe('SpellingAnalyzerJob', () => {
         }),
       ];
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
 
       const result = await analyzer.analyze(chunks, 'This is thier house\nThey dont know');
 
@@ -175,7 +173,7 @@ describe('SpellingAnalyzerJob', () => {
         }
       });
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
 
       const result = await analyzer.analyze([new TextChunk('No errors here.', 'chunk1')], 'No errors here.');
 
@@ -190,7 +188,7 @@ describe('SpellingAnalyzerJob', () => {
         errors: [],
       }));
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
 
       const chunks = [new TextChunk('Test', 'chunk1')];
       const result1 = await analyzer.analyze(chunks, 'Test');
@@ -204,7 +202,7 @@ describe('SpellingAnalyzerJob', () => {
 
   describe('getResults', () => {
     it('should throw error if analysis not run', () => {
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
 
       expect(() => analyzer.getResults()).toThrow(
         'Analysis has not been run yet. Call analyze() first.'
@@ -223,7 +221,7 @@ describe('SpellingAnalyzerJob', () => {
         }],
       }));
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
 
       const chunks = [
         Object.assign(new TextChunk('teh', 'chunk1', { position: { start: 0, end: 3 } }), {
@@ -261,7 +259,7 @@ describe('SpellingAnalyzerJob', () => {
 
       (checkSpellingGrammarTool.execute as any).mockImplementation(() => Promise.resolve({ errors: [] }));
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
       const result = await analyzer.analyze(
         [new TextChunk('Text with organize and colour', 'chunk1')], 
         'Text with organize and colour'
@@ -304,7 +302,7 @@ describe('SpellingAnalyzerJob', () => {
         findTextAbsolute: vi.fn().mockImplementation(() => Promise.resolve(null)) // Cannot find location
       });
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
       const result = await analyzer.analyze([chunk], 'This text does not contain the error');
 
       // Should not create comment for unlocatable error
@@ -332,7 +330,7 @@ describe('SpellingAnalyzerJob', () => {
         }
       );
 
-      const analyzer = new SpellingAnalyzerJob();
+      const analyzer = new SpellingPlugin();
       const result = await analyzer.analyze([chunk], 'I will recieve teh package');
 
       expect(result.comments).toHaveLength(2);
@@ -369,7 +367,7 @@ describe('SpellingAnalyzerJob', () => {
           }))
         });
 
-        const analyzer = new SpellingAnalyzerJob();
+        const analyzer = new SpellingPlugin();
         const result = await analyzer.analyze([chunk], 'error');
 
         // Importance is not currently being set by the implementation

--- a/internal-packages/ai/src/tools/check-spelling-grammar/check-spelling-grammar.e2e.vtest.ts
+++ b/internal-packages/ai/src/tools/check-spelling-grammar/check-spelling-grammar.e2e.vtest.ts
@@ -152,8 +152,8 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
 
               expect(error).toBeDefined();
               expect(error?.type).toBe("spelling");
-              if (error?.conciseCorrection) {
-                expect(error.conciseCorrection.toLowerCase()).toMatch(
+              if (error?.displayCorrection) {
+                expect(error.displayCorrection.toLowerCase()).toMatch(
                   /teh\s*→\s*the/i
                 );
               }
@@ -172,8 +172,8 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
               );
               expect(error).toBeDefined();
               expect(error?.type).toBe("spelling");
-              if (error?.conciseCorrection) {
-                expect(error.conciseCorrection.toLowerCase()).toMatch(
+              if (error?.displayCorrection) {
+                expect(error.displayCorrection.toLowerCase()).toMatch(
                   /recieve\s*→\s*receive/i
                 );
               }
@@ -188,7 +188,7 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
               const error = result.errors.find((e) => e.text === "algorithem");
               expect(error).toBeDefined();
               expect(error?.correction).toBe("algorithm");
-              expect(error?.conciseCorrection).toMatch(
+              expect(error?.displayCorrection).toMatch(
                 /algorithem\s*→\s*algorithm/
               );
               expect(error?.type).toBe("spelling");
@@ -208,8 +208,8 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
               expect(errors).toContain("recieved");
               expect(errors).toContain("thier");
               result.errors.forEach((error) => {
-                expect(error.conciseCorrection).toBeTruthy();
-                expect(error.conciseCorrection).toMatch(/→/);
+                expect(error.displayCorrection).toBeTruthy();
+                expect(error.displayCorrection).toMatch(/→/);
               });
             },
           },
@@ -245,7 +245,7 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
               const error = result.errors.find((e) => e.text === "their");
               expect(error).toBeDefined();
               expect(error?.correction).toBe("there");
-              expect(error?.conciseCorrection).toMatch(/their\s*→\s*there/);
+              expect(error?.displayCorrection).toMatch(/their\s*→\s*there/);
               // Their/there confusion can be classified as either spelling or grammar
               expect(["spelling", "grammar"]).toContain(error?.type);
               expect(error?.importance).toBeGreaterThanOrEqual(26);
@@ -266,7 +266,7 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
                 );
                 if (error) {
                   expect(error.correction).toMatch(/is/);
-                  expect(error.conciseCorrection).toBeTruthy();
+                  expect(error.displayCorrection).toBeTruthy();
                   expect(error.type).toBe("grammar");
                   expect(error.importance).toBeGreaterThanOrEqual(26);
                   expect(error.importance).toBeLessThanOrEqual(75);
@@ -721,10 +721,10 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
             input: { text: "I recieved teh package." },
             expectations: (result) => {
               result.errors.forEach((error) => {
-                expect(error.conciseCorrection).toBeTruthy();
-                expect(error.conciseCorrection).toMatch(/→/);
+                expect(error.displayCorrection).toBeTruthy();
+                expect(error.displayCorrection).toMatch(/→/);
                 // Should be concise - not full sentences
-                expect(error.conciseCorrection.length).toBeLessThan(50);
+                expect(error.displayCorrection.length).toBeLessThan(50);
               });
             },
           },
@@ -737,7 +737,7 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
                 result.errors.map((e) => ({
                   text: e.text,
                   correction: e.correction,
-                  conciseCorrection: e.conciseCorrection,
+                  displayCorrection: e.displayCorrection,
                 }))
               );
 
@@ -754,8 +754,8 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
                 );
               }
 
-              if (error?.conciseCorrection) {
-                expect(error.conciseCorrection.toLowerCase()).toMatch(
+              if (error?.displayCorrection) {
+                expect(error.displayCorrection.toLowerCase()).toMatch(
                   /is\s*→\s*are/i
                 );
               }
@@ -769,7 +769,7 @@ describeIfApiKey("CheckSpellingGrammarTool Integration", () => {
                 e.text.includes("could of")
               );
               if (error) {
-                expect(error.conciseCorrection).toMatch(
+                expect(error.displayCorrection).toMatch(
                   /could of\s*→\s*could have/
                 );
               }


### PR DESCRIPTION
### **User description**
## Summary
- Standardizes plugin naming across all analysis plugins
- Removes backward compatibility aliases that are no longer needed
- Updates test files to use consistent naming

## Changes
- ✅ Renamed `SpellingAnalyzerJob` → `SpellingPlugin`
- ✅ Renamed `MathAnalyzerJob` → `MathPlugin`  
- ✅ Renamed `ForecastAnalyzerJob` → `ForecastPlugin`
- ✅ Removed backward compatibility alias exports
- ✅ Updated all test files to use new plugin names
- ✅ Replaced `conciseCorrection` with `displayCorrection` in tests

## Test Results
All tests pass:
- 62 test files passed
- 603 tests passed
- 0 failures

## Rationale
This change establishes consistent naming across all analysis plugins, following the simpler `XXXPlugin` convention rather than `XXXAnalyzerJob`. This makes the codebase more maintainable and easier to understand.

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Standardize plugin naming from `XXXAnalyzerJob` to `XXXPlugin`

- Remove backward compatibility alias exports

- Update test files to use new naming

- Replace `conciseCorrection` with `displayCorrection` in tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SpellingAnalyzerJob"] --> B["SpellingPlugin"]
  C["MathAnalyzerJob"] --> D["MathPlugin"]
  E["ForecastAnalyzerJob"] --> F["ForecastPlugin"]
  G["Backward Compatibility Aliases"] --> H["Removed"]
  I["Test Files"] --> J["Updated to New Names"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Rename ForecastAnalyzerJob to ForecastPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/forecast/index.ts

<ul><li>Rename <code>ForecastAnalyzerJob</code> class to <code>ForecastPlugin</code><br> <li> Remove backward compatibility alias export</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-eca7f35bfd15728ca8602e7322bfc9cd30c7cc5f684a44d82b161f90fb778bb7">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Rename MathAnalyzerJob to MathPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/math/index.ts

<ul><li>Rename <code>MathAnalyzerJob</code> class to <code>MathPlugin</code><br> <li> Remove backward compatibility alias export</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-55d556f5ee2dc9745f57d6aa176acd0b30abb821a6459f28e9cefd284b78fb87">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Rename SpellingAnalyzerJob to SpellingPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/spelling/index.ts

<ul><li>Rename <code>SpellingAnalyzerJob</code> class to <code>SpellingPlugin</code><br> <li> Remove backward compatibility alias export</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-936a39ee178bdb2be4f185afc8577f154655fdf966ec79d3756d347d1a32232a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>math.llm.vtest.ts</strong><dd><code>Update integration test to use MathPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/math/math.llm.vtest.ts

<ul><li>Update import to use <code>MathPlugin</code> instead of <code>MathAnalyzerJob</code><br> <li> Update instantiation to use new class name</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-72922a1ae08ede81a495417c930935e9c77ffa99110e92ed9b5621dbaeddfb9e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>math.vtest.ts</strong><dd><code>Update unit tests for MathPlugin naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/math/math.vtest.ts

<ul><li>Update import and all references to use <code>MathPlugin</code><br> <li> Replace <code>conciseCorrection</code> with <code>displayCorrection</code> in mock data<br> <li> Update test suite name and instantiations</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-a94d57a8b821dc9af24bdbefb27de875c12a3fd6caa914bed0206c0a583f7de6">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spelling.llm.vtest.ts</strong><dd><code>Update integration test to use SpellingPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/spelling/spelling.llm.vtest.ts

<ul><li>Update import to use <code>SpellingPlugin</code> instead of <code>SpellingAnalyzerJob</code><br> <li> Update test suite name and instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-a580709bdd37ea54e48a28b4fd079f1b6b96b9e155b4e66544b4afa6ae054ace">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spelling.vtest.ts</strong><dd><code>Update unit tests for SpellingPlugin naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/analysis-plugins/plugins/spelling/spelling.vtest.ts

<ul><li>Update import and all references to use <code>SpellingPlugin</code><br> <li> Update test suite name and instantiations<br> <li> Remove <code>conciseCorrection</code> from mock error objects</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-8290390216f89c55dfe95c76863c1bc3ded39c0b262820b77502d8fe10b1dbf4">+14/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>check-spelling-grammar.e2e.vtest.ts</strong><dd><code>Update e2e tests to use displayCorrection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/tools/check-spelling-grammar/check-spelling-grammar.e2e.vtest.ts

<ul><li>Replace all <code>conciseCorrection</code> references with <code>displayCorrection</code><br> <li> Update test expectations to use new property name</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/238/files#diff-8584bc8c11af4f410cec71605f59cce8769468760bd979ca5d9dade06b0132a6">+16/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized plugin names: Forecast, Math, and Spelling now export as “<Plugin>Plugin” (e.g., MathPlugin), removing legacy aliases.
  - Renamed result field “conciseCorrection” to “displayCorrection” across math, spelling, and spelling/grammar outputs for clearer presentation.
  - Spelling analysis summary text refined to read “Minor writing quality issues detected.”
- Tests
  - Updated test suites to use the new plugin names and the “displayCorrection” field, aligning expectations and assertions with the refined outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->