### PR TITLE
UI improvements for document management and privacy controls

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/apps/web/src/app/docs/[docId]/components/EvaluationManagement.tsx
+++ b/apps/web/src/app/docs/[docId]/components/EvaluationManagement.tsx
@@ -1,19 +1,23 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+
+import { Loader2, Plus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { 
-  BeakerIcon,
-  ArrowPathIcon,
-  PlusIcon,
-} from "@heroicons/react/24/outline";
+
+import {
+  createOrRerunEvaluation,
+  deleteEvaluation,
+} from "@/app/docs/[docId]/actions/evaluation-actions";
 import { AgentBadges } from "@/components/AgentBadges";
-import { createOrRerunEvaluation, deleteEvaluation } from "@/app/docs/[docId]/actions/evaluation-actions";
+import { Button } from "@/components/ui/button";
 import { useEvaluationRerun } from "@/shared/hooks/useEvaluationRerun";
-import { sortAgentsByBadgeStatus } from "@/shared/utils/agentSorting";
-import { ManagementEvaluationCard } from "./ManagementEvaluationCard";
 import type { Evaluation } from "@/shared/types/databaseTypes";
+import { sortAgentsByBadgeStatus } from "@/shared/utils/agentSorting";
+import { BeakerIcon } from "@heroicons/react/24/outline";
+
+import { ManagementEvaluationCard } from "./ManagementEvaluationCard";
 
 interface Agent {
   id: string;
@@ -32,9 +36,16 @@ interface EvaluationManagementProps {
   isOwner: boolean;
 }
 
-export function EvaluationManagement({ docId, evaluations, availableAgents, isOwner }: EvaluationManagementProps) {
+export function EvaluationManagement({
+  docId,
+  evaluations,
+  availableAgents,
+  isOwner,
+}: EvaluationManagementProps) {
   const router = useRouter();
-  const { handleRerun, runningEvals } = useEvaluationRerun({ documentId: docId });
+  const { handleRerun, runningEvals } = useEvaluationRerun({
+    documentId: docId,
+  });
   const [runningAgents, setRunningAgents] = useState<Set<string>>(new Set());
   const [deletingEvals, setDeletingEvals] = useState<Set<string>>(new Set());
   const [sortedAgents, setSortedAgents] = useState<Agent[]>([]);
@@ -46,14 +57,14 @@ export function EvaluationManagement({ docId, evaluations, availableAgents, isOw
   }, [availableAgents]);
 
   const handleAddAgent = async (agentId: string) => {
-    setRunningAgents(prev => new Set([...prev, agentId]));
+    setRunningAgents((prev) => new Set([...prev, agentId]));
     try {
       await createOrRerunEvaluation(agentId, docId);
       router.refresh();
     } catch (error) {
-      console.error('Failed to add agent evaluation:', error);
+      console.error("Failed to add agent evaluation:", error);
     } finally {
-      setRunningAgents(prev => {
+      setRunningAgents((prev) => {
         const next = new Set(prev);
         next.delete(agentId);
         return next;
@@ -62,24 +73,28 @@ export function EvaluationManagement({ docId, evaluations, availableAgents, isOw
   };
 
   const handleDeleteEvaluation = async (agentId: string) => {
-    if (!window.confirm('Are you sure you want to delete this evaluation? This will remove all related data including analysis, comments, and history.')) {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this evaluation? This will remove all related data including analysis, comments, and history."
+      )
+    ) {
       return;
     }
-    
-    setDeletingEvals(prev => new Set([...prev, agentId]));
+
+    setDeletingEvals((prev) => new Set([...prev, agentId]));
     try {
       const result = await deleteEvaluation(agentId, docId);
       if (result.success) {
         router.refresh();
       } else {
-        console.error('Failed to delete evaluation:', result.error);
+        console.error("Failed to delete evaluation:", result.error);
         alert(`Failed to delete evaluation: ${result.error}`);
       }
     } catch (error) {
-      console.error('Failed to delete evaluation:', error);
-      alert('Failed to delete evaluation. Please try again.');
+      console.error("Failed to delete evaluation:", error);
+      alert("Failed to delete evaluation. Please try again.");
     } finally {
-      setDeletingEvals(prev => {
+      setDeletingEvals((prev) => {
         const next = new Set(prev);
         next.delete(agentId);
         return next;
@@ -87,22 +102,23 @@ export function EvaluationManagement({ docId, evaluations, availableAgents, isOw
     }
   };
 
-
   return (
     <>
       {/* Active Evaluations */}
       <div className="mb-8">
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">
-          Active Evaluations ({evaluations.length})
+        <h2 className="mb-1 text-lg font-semibold text-gray-900">
+          Document Evaluations ({evaluations.length})
         </h2>
-        <p className="text-sm text-gray-600 mb-6">
+        <p className="mb-6 text-sm text-gray-600">
           Manage and monitor your AI agent evaluations
         </p>
 
         <div className="space-y-6">
           {evaluations.length === 0 ? (
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
-              <p className="text-gray-500">No evaluations yet. Add agents below to get started.</p>
+            <div className="rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
+              <p className="text-gray-500">
+                No evaluations yet. Add agents below to get started.
+              </p>
             </div>
           ) : (
             evaluations.map((evaluation) => (
@@ -123,32 +139,32 @@ export function EvaluationManagement({ docId, evaluations, availableAgents, isOw
 
       {/* Add More Agents */}
       {isOwner && sortedAgents.length > 0 && (
-        <div className="bg-gray-50 rounded-lg p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+        <div className="rounded-lg bg-gray-50 py-6">
+          <h2 className="mb-1 text-lg font-semibold text-gray-900">
             Add More Agents
           </h2>
-          <p className="text-sm text-gray-600 mb-6">
+          <p className="mb-6 text-sm text-gray-600">
             Available agents to evaluate your document
           </p>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {sortedAgents.map((agent) => {
               const isRunning = runningAgents.has(agent.id);
 
               return (
                 <div
                   key={agent.id}
-                  className="bg-white rounded-lg border border-gray-200 p-5 flex items-center justify-between"
+                  className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-5"
                 >
-                  <div className="flex items-start gap-3 flex-1">
+                  <div className="flex flex-1 items-start gap-3">
                     <div className="p-1.5">
                       <BeakerIcon className="h-4 w-4 text-gray-500" />
                     </div>
-                    <div className="flex-1 min-w-0">
+                    <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <Link 
+                        <Link
                           href={`/agents/${agent.id}`}
-                          className="font-medium text-gray-900 hover:text-gray-700 truncate"
+                          className="truncate font-medium text-gray-900 hover:text-gray-700"
                         >
                           {agent.name}
                         </Link>
@@ -161,36 +177,38 @@ export function EvaluationManagement({ docId, evaluations, availableAgents, isOw
                         />
                       </div>
                       {agent.description && (
-                        <p className="text-sm text-gray-500 line-clamp-2 mt-1">
+                        <p className="mt-1 line-clamp-2 text-sm text-gray-500">
                           {agent.description}
                         </p>
                       )}
                     </div>
                   </div>
-                  <button
+                  <Button
                     onClick={() => handleAddAgent(agent.id)}
                     disabled={isRunning}
-                    className="ml-4 flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    variant="outline"
+                    size="sm"
+                    className="ml-4 flex-shrink-0"
                   >
                     {isRunning ? (
                       <>
-                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                        <Loader2 className="h-4 w-4 animate-spin" />
                         Adding...
                       </>
                     ) : (
                       <>
-                        <PlusIcon className="h-4 w-4" />
+                        <Plus className="h-4 w-4" />
                         Add
                       </>
                     )}
-                  </button>
+                  </Button>
                 </div>
               );
             })}
           </div>
 
           {sortedAgents.length > 0 && (
-            <p className="text-sm text-gray-500 text-center mt-4">
+            <p className="mt-4 text-center text-sm text-gray-500">
               Showing all {sortedAgents.length} available agents
             </p>
           )}

--- a/apps/web/src/app/docs/[docId]/components/ManagementEvaluationCard.tsx
+++ b/apps/web/src/app/docs/[docId]/components/ManagementEvaluationCard.tsx
@@ -7,13 +7,11 @@ import {
   EvaluationActions,
 } from "@/components/EvaluationCard/shared/EvaluationActions";
 import {
-  EvaluationHeader,
-} from "@/components/EvaluationCard/shared/EvaluationHeader";
-import {
   EvaluationStats,
 } from "@/components/EvaluationCard/shared/EvaluationStats";
 import { GradeBadge } from "@/components/GradeBadge";
 import { StatusBadge } from "@/components/StatusBadge";
+import { StaleBadge } from "@/components/StaleBadge";
 import type { Evaluation } from "@/shared/types/databaseTypes";
 import { getEvaluationStatus } from "@/shared/utils/evaluationStatus";
 import {
@@ -101,21 +99,17 @@ export function ManagementEvaluationCard({
               <BeakerIcon className="h-4 w-4 flex-shrink-0 text-gray-500" />
             </div>
             <div className="min-w-0 flex-1">
-              <EvaluationHeader
-                agentName={evaluation.agent.name}
-                grade={latestGrade}
-                isStale={isStale}
-                isRerunning={isRerunning}
-                evaluationStatus={evaluationStatus}
-                showGrade={false}
-              >
+              <div className="flex items-center gap-2">
                 <Link
                   href={`/agents/${agentId}`}
-                  className="ml-1 text-gray-400 hover:text-gray-600"
+                  className="text-sm font-semibold text-gray-700 hover:text-gray-900"
                 >
-                  →
+                  {evaluation.agent.name}
                 </Link>
-              </EvaluationHeader>
+                {isStale && (
+                  <StaleBadge size="sm" />
+                )}
+              </div>
               <div className="mt-0.5">
                 <EvaluationStats
                   versionCount={versionCount}
@@ -146,6 +140,7 @@ export function ManagementEvaluationCard({
               showRerun={isOwner}
               showDelete={isOwner}
               showDetails={true}
+              detailsText="View Results"
               detailsStyle="button"
               className="flex items-center gap-2"
             />
@@ -157,18 +152,12 @@ export function ManagementEvaluationCard({
       {latestVersion && (
         <div className="border-t border-gray-100 bg-gray-50 px-5 py-4">
           <div className="flex items-start gap-4">
-            {/* Grade badge */}
-            <div className="flex-shrink-0">
-              {latestGrade !== null && latestGrade !== undefined ? (
+            {/* Grade badge - only show if grade exists */}
+            {latestGrade !== null && latestGrade !== undefined && (
+              <div className="flex-shrink-0">
                 <GradeBadge grade={latestGrade} variant="grayscale" size="md" />
-              ) : (
-                <div className="rounded bg-gray-100 px-3 py-1">
-                  <span className="text-sm font-semibold text-gray-400">
-                    N/A
-                  </span>
-                </div>
-              )}
-            </div>
+              </div>
+            )}
 
             {/* Summary and metadata */}
             <div className="min-w-0 flex-1">
@@ -205,7 +194,7 @@ export function ManagementEvaluationCard({
                     <span>•</span>
                     <Link
                       href={`/docs/${docId}/evals/${agentId}/logs`}
-                      className="text-purple-700 hover:text-purple-900"
+                      className="text-blue-600 hover:text-blue-800"
                     >
                       Logs
                     </Link>

--- a/apps/web/src/app/docs/[docId]/components/PrivacySection.tsx
+++ b/apps/web/src/app/docs/[docId]/components/PrivacySection.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { PrivacyBadge } from "@/components/PrivacyBadge";
+import { toggleDocumentPrivacy } from "../reader/actions";
+
+interface PrivacySectionProps {
+  docId: string;
+  isPrivate: boolean;
+  isOwner: boolean;
+}
+
+export function PrivacySection({ docId, isPrivate: initialPrivacy, isOwner }: PrivacySectionProps) {
+  const [isPrivate, setIsPrivate] = useState(initialPrivacy);
+  const [isChanging, setIsChanging] = useState(false);
+  const router = useRouter();
+
+  const handleTogglePrivacy = async () => {
+    console.log('Toggle privacy clicked for doc:', docId);
+    setIsChanging(true);
+    try {
+      const result = await toggleDocumentPrivacy(docId);
+      console.log('Toggle result:', result);
+      if (result.success && result.isPrivate !== undefined) {
+        setIsPrivate(result.isPrivate);
+        router.refresh();
+      } else {
+        alert(result.error || 'Failed to change privacy');
+      }
+    } catch (error) {
+      console.error('Error changing privacy:', error);
+      alert('Failed to change privacy');
+    } finally {
+      setIsChanging(false);
+    }
+  };
+
+  return (
+    <div>
+      <dt className="text-sm font-medium text-gray-500">
+        Privacy
+      </dt>
+      <dd className="mt-1 flex items-center justify-between">
+        <PrivacyBadge
+          isPrivate={isPrivate}
+          variant="badge"
+          size="sm"
+        />
+        {isOwner && (
+          <button
+            className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50"
+            onClick={handleTogglePrivacy}
+            disabled={isChanging}
+          >
+            {isChanging ? 'Changing...' : isPrivate ? 'Make Public' : 'Make Private'}
+          </button>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/src/app/docs/[docId]/edit/page.tsx
+++ b/apps/web/src/app/docs/[docId]/edit/page.tsx
@@ -18,7 +18,9 @@ import { z } from "zod";
 import { Button } from "@/components/Button";
 import { FormField } from "@/components/FormField";
 import { WarningDialog } from "@/components/WarningDialog";
-import { LockClosedIcon } from "@heroicons/react/24/outline";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { LockClosedIcon, GlobeAltIcon } from "@heroicons/react/24/outline";
 
 import {
   type DocumentInput,
@@ -315,22 +317,38 @@ export default function EditDocumentPage({ params }: Props) {
                 />
               </FormField>
 
-              <div className="flex items-start">
-                <label className="flex items-start gap-3 cursor-pointer">
-                  <input
-                    {...methods.register("isPrivate")}
-                    type="checkbox"
-                    className="mt-1 rounded text-indigo-600 focus:ring-indigo-500"
-                  />
-                  <div className="flex items-start gap-2">
-                    <LockClosedIcon className="h-5 w-5 text-gray-500 mt-0.5" />
-                    <div>
-                      <div className="text-sm font-medium text-gray-900">Make this document private</div>
-                      <div className="text-xs text-gray-500">Only you will be able to view this document. Public by default.</div>
-                    </div>
+              <FormField
+                name="isPrivate"
+                label="Privacy"
+                error={errors.isPrivate}
+              >
+                <RadioGroup
+                  value={methods.watch("isPrivate") ? "private" : "public"}
+                  onValueChange={(value: string) => methods.setValue("isPrivate", value === "private")}
+                  className="flex gap-6"
+                >
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="public" id="public" />
+                    <Label htmlFor="public" className="flex items-center gap-2 cursor-pointer">
+                      <GlobeAltIcon className="h-4 w-4 text-gray-500" />
+                      <div>
+                        <div className="text-sm font-medium">Public</div>
+                        <div className="text-xs text-gray-500">Anyone can view this document</div>
+                      </div>
+                    </Label>
                   </div>
-                </label>
-              </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="private" id="private" />
+                    <Label htmlFor="private" className="flex items-center gap-2 cursor-pointer">
+                      <LockClosedIcon className="h-4 w-4 text-gray-500" />
+                      <div>
+                        <div className="text-sm font-medium">Private</div>
+                        <div className="text-xs text-gray-500">Only you can view this document</div>
+                      </div>
+                    </Label>
+                  </div>
+                </RadioGroup>
+              </FormField>
 
               {errors.root && (
                 <div className="rounded-md bg-red-50 p-4">

--- a/apps/web/src/app/docs/import/page.tsx
+++ b/apps/web/src/app/docs/import/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { logger } from "@/infrastructure/logging/logger";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/Button";
+import { logger } from "@/infrastructure/logging/logger";
 import { CheckIcon } from "@heroicons/react/24/solid";
 
 import { importDocument } from "./actions";
@@ -31,9 +31,11 @@ export default function ImportPage() {
         const data = await response.json();
         setAgents(data.agents || []);
         // Select all agents by default
-        setSelectedAgentIds((data.agents || []).map((agent: Agent) => agent.id));
+        setSelectedAgentIds(
+          (data.agents || []).map((agent: Agent) => agent.id)
+        );
       } catch (error) {
-        logger.error('Error fetching agents:', error);
+        logger.error("Error fetching agents:", error);
       } finally {
         setLoadingAgents(false);
       }
@@ -42,13 +44,12 @@ export default function ImportPage() {
   }, []);
 
   const toggleAgent = (agentId: string) => {
-    setSelectedAgentIds(prev => 
-      prev.includes(agentId) 
-        ? prev.filter(id => id !== agentId)
+    setSelectedAgentIds((prev) =>
+      prev.includes(agentId)
+        ? prev.filter((id) => id !== agentId)
         : [...prev, agentId]
     );
   };
-
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -103,19 +104,19 @@ export default function ImportPage() {
               Run evaluations after import
             </label>
           </div>
-          
+
           {loadingAgents ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4">
-              {[1, 2, 3, 4].map(i => (
-                <div key={i} className="h-20 bg-gray-100 rounded-lg"></div>
+            <div className="grid grid-cols-1 gap-3 rounded-lg border border-gray-200 p-4 md:grid-cols-2">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="h-20 rounded-lg bg-gray-100"></div>
               ))}
             </div>
           ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto">
-              {agents.map(agent => (
+            <div className="grid max-h-96 grid-cols-1 gap-3 overflow-y-auto rounded-lg border border-gray-200 p-4 md:grid-cols-2">
+              {agents.map((agent) => (
                 <label
                   key={agent.id}
-                  className="flex items-start gap-3 p-3 rounded-lg border border-gray-100 hover:bg-gray-50 hover:border-gray-200 cursor-pointer transition-colors"
+                  className="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-100 p-3 transition-colors hover:border-gray-200 hover:bg-gray-50"
                 >
                   <input
                     type="checkbox"
@@ -123,21 +124,27 @@ export default function ImportPage() {
                     onChange={() => toggleAgent(agent.id)}
                     className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                   />
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-gray-900">{agent.name}</div>
-                    <div className="text-sm text-gray-600 mt-1">{agent.description}</div>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium text-gray-900">
+                      {agent.name}
+                    </div>
+                    <div className="mt-1 text-sm text-gray-600">
+                      {agent.description}
+                    </div>
                   </div>
                   {selectedAgentIds.includes(agent.id) && (
-                    <CheckIcon className="h-5 w-5 text-blue-600 flex-shrink-0 mt-1" />
+                    <CheckIcon className="mt-1 h-5 w-5 flex-shrink-0 text-blue-600" />
                   )}
                 </label>
               ))}
             </div>
           )}
-          
+
           {selectedAgentIds.length > 0 && (
             <p className="text-sm text-gray-600">
-              {selectedAgentIds.length} evaluation{selectedAgentIds.length !== 1 ? 's' : ''} will be queued after import
+              {selectedAgentIds.length} evaluation
+              {selectedAgentIds.length !== 1 ? "s" : ""} will be queued after
+              import
             </p>
           )}
         </div>
@@ -154,10 +161,10 @@ export default function ImportPage() {
               <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>
               Importing...
             </div>
+          ) : selectedAgentIds.length > 0 ? (
+            `Import & Run ${selectedAgentIds.length} Evaluation${selectedAgentIds.length !== 1 ? "s" : ""}`
           ) : (
-            selectedAgentIds.length > 0 
-              ? `Import & Run ${selectedAgentIds.length} Evaluation${selectedAgentIds.length !== 1 ? 's' : ''}`
-              : "Import Document"
+            "Import Document"
           )}
         </Button>
       </form>
@@ -170,14 +177,8 @@ export default function ImportPage() {
       )}
 
       <div className="mt-6 text-sm text-gray-600">
-        <p>Supported platforms:</p>
-        <ul className="mt-2 list-inside list-disc space-y-1">
-          <li>LessWrong</li>
-          <li>EA Forum</li>
-          <li>Medium</li>
-          <li>Substack</li>
-          <li>General web articles</li>
-        </ul>
+        Supports LessWrong and the EA Forum. Attempts to fetch article content
+        from other platforms.
       </div>
     </div>
   );

--- a/apps/web/src/app/docs/new/CreateDocumentForm.tsx
+++ b/apps/web/src/app/docs/new/CreateDocumentForm.tsx
@@ -1,30 +1,36 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { logger } from "@/infrastructure/logging/logger";
+import { useEffect, useState } from "react";
+
 import Link from "next/link";
 import { FormProvider, useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
+import { AgentBadges } from "@/components/AgentBadges";
 import { Button } from "@/components/Button";
 import { FormField } from "@/components/FormField";
-import { AgentBadges } from "@/components/AgentBadges";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
-import { 
-  LinkIcon, 
-  DocumentTextIcon,
-  CheckIcon,
-  LockClosedIcon,
-  GlobeAltIcon,
-} from "@heroicons/react/24/outline";
-
-import { createDocument } from "./actions";
-import { importDocument } from "../import/actions";
-import { type DocumentInput, documentSchema, CONTENT_MIN_CHARS, CONTENT_MAX_WORDS } from "./schema";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { logger } from "@/infrastructure/logging/logger";
 import { sortAgentsByBadgeStatus } from "@/shared/utils/agentSorting";
+import {
+  CheckIcon,
+  DocumentTextIcon,
+  GlobeAltIcon,
+  LinkIcon,
+  LockClosedIcon,
+} from "@heroicons/react/24/outline";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { importDocument } from "../import/actions";
+import { createDocument } from "./actions";
 import { useContentValidation } from "./hooks/useContentValidation";
+import {
+  CONTENT_MAX_WORDS,
+  CONTENT_MIN_CHARS,
+  type DocumentInput,
+  documentSchema,
+} from "./schema";
 
 interface FormFieldConfig {
   name: keyof DocumentInput;
@@ -81,7 +87,11 @@ interface PrivacyToggleProps {
   useRegister?: any; // For react-hook-form register
 }
 
-function PrivacyToggle({ isPrivate, onChange, useRegister }: PrivacyToggleProps) {
+function PrivacyToggle({
+  isPrivate,
+  onChange,
+  useRegister,
+}: PrivacyToggleProps) {
   return (
     <div className="space-y-3">
       <label className="text-sm font-medium text-gray-900">
@@ -94,21 +104,31 @@ function PrivacyToggle({ isPrivate, onChange, useRegister }: PrivacyToggleProps)
       >
         <div className="flex items-center space-x-2">
           <RadioGroupItem value="public" id="create-public" />
-          <Label htmlFor="create-public" className="flex items-center gap-2 cursor-pointer">
+          <Label
+            htmlFor="create-public"
+            className="flex cursor-pointer items-center gap-2"
+          >
             <GlobeAltIcon className="h-4 w-4 text-gray-500" />
             <div>
               <div className="text-sm font-medium">Public</div>
-              <div className="text-xs text-gray-500">Anyone can view this document</div>
+              <div className="text-xs text-gray-500">
+                Anyone can view this document
+              </div>
             </div>
           </Label>
         </div>
         <div className="flex items-center space-x-2">
           <RadioGroupItem value="private" id="create-private" />
-          <Label htmlFor="create-private" className="flex items-center gap-2 cursor-pointer">
+          <Label
+            htmlFor="create-private"
+            className="flex cursor-pointer items-center gap-2"
+          >
             <LockClosedIcon className="h-4 w-4 text-gray-500" />
             <div>
               <div className="text-sm font-medium">Private</div>
-              <div className="text-xs text-gray-500">Only you can view this document</div>
+              <div className="text-xs text-gray-500">
+                Only you can view this document
+              </div>
             </div>
           </Label>
         </div>
@@ -127,14 +147,14 @@ interface AgentSelectorProps {
   layout?: "grid" | "list";
 }
 
-function AgentSelector({ 
-  agents, 
-  selectedAgentIds, 
-  onToggleAgent, 
-  loading, 
+function AgentSelector({
+  agents,
+  selectedAgentIds,
+  onToggleAgent,
+  loading,
   title = "Evaluations to run",
   actionText = "will be queued",
-  layout = "grid"
+  layout = "grid",
 }: AgentSelectorProps) {
   if (loading) {
     return (
@@ -142,7 +162,7 @@ function AgentSelector({
         <label className="block text-sm font-medium text-gray-700">
           {title}
         </label>
-        <div className="flex items-center justify-center p-8 rounded-lg border border-gray-200">
+        <div className="flex items-center justify-center rounded-lg border border-gray-200 p-8">
           <div className="h-5 w-5 animate-spin rounded-full border-b-2 border-gray-600"></div>
         </div>
       </div>
@@ -155,26 +175,25 @@ function AgentSelector({
         <label className="block text-sm font-medium text-gray-700">
           {title}
         </label>
-        <p className="text-sm text-gray-500 italic">No evaluations available</p>
+        <p className="text-sm italic text-gray-500">No evaluations available</p>
       </div>
     );
   }
 
-  const containerClass = layout === "grid" 
-    ? "grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto"
-    : "space-y-2 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto";
+  const containerClass =
+    layout === "grid"
+      ? "grid grid-cols-1 md:grid-cols-2 gap-3 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto"
+      : "space-y-2 rounded-lg border border-gray-200 p-4 max-h-96 overflow-y-auto";
 
   return (
     <div className="space-y-3">
-      <label className="block text-sm font-medium text-gray-700">
-        {title}
-      </label>
-      
+      <label className="block text-sm font-medium text-gray-700">{title}</label>
+
       <div className={containerClass}>
-        {agents.map(agent => (
+        {agents.map((agent) => (
           <label
             key={agent.id}
-            className="flex items-start gap-3 p-3 rounded-lg border border-gray-100 hover:bg-gray-50 hover:border-gray-200 cursor-pointer transition-colors"
+            className="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-100 p-3 transition-colors hover:border-gray-200 hover:bg-gray-50"
           >
             <input
               type="checkbox"
@@ -182,7 +201,7 @@ function AgentSelector({
               onChange={() => onToggleAgent(agent.id)}
               className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             />
-            <div className="flex-1 min-w-0">
+            <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 <span className="font-medium text-gray-900">{agent.name}</span>
                 <AgentBadges
@@ -193,18 +212,21 @@ function AgentSelector({
                   size="sm"
                 />
               </div>
-              <div className="text-sm text-gray-600 mt-1">{agent.description}</div>
+              <div className="mt-1 text-sm text-gray-600">
+                {agent.description}
+              </div>
             </div>
             {selectedAgentIds.includes(agent.id) && (
-              <CheckIcon className="h-5 w-5 text-blue-600 flex-shrink-0 mt-1" />
+              <CheckIcon className="mt-1 h-5 w-5 flex-shrink-0 text-blue-600" />
             )}
           </label>
         ))}
       </div>
-      
+
       {selectedAgentIds.length > 0 && (
         <p className="text-sm text-gray-600">
-          {selectedAgentIds.length} evaluation{selectedAgentIds.length !== 1 ? 's' : ''} {actionText}
+          {selectedAgentIds.length} evaluation
+          {selectedAgentIds.length !== 1 ? "s" : ""} {actionText}
         </p>
       )}
     </div>
@@ -235,16 +257,17 @@ interface SubmitButtonProps {
   disabled?: boolean;
 }
 
-function SubmitButton({ 
-  isSubmitting, 
-  selectedAgentCount, 
-  baseText, 
+function SubmitButton({
+  isSubmitting,
+  selectedAgentCount,
+  baseText,
   submittingText,
-  disabled = false 
+  disabled = false,
 }: SubmitButtonProps) {
-  const buttonText = selectedAgentCount > 0 
-    ? `${baseText} & Run ${selectedAgentCount} Evaluation${selectedAgentCount !== 1 ? 's' : ''}`
-    : baseText;
+  const buttonText =
+    selectedAgentCount > 0
+      ? `${baseText} & Run ${selectedAgentCount} Evaluation${selectedAgentCount !== 1 ? "s" : ""}`
+      : baseText;
 
   return (
     <Button type="submit" disabled={disabled || isSubmitting}>
@@ -268,7 +291,7 @@ export default function CreateDocumentForm() {
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [importIsPrivate, setImportIsPrivate] = useState(true); // Default to private
-  
+
   // Agent selection state
   const [agents, setAgents] = useState<Agent[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
@@ -291,10 +314,11 @@ export default function CreateDocumentForm() {
     setError,
     watch,
   } = methods;
-  
+
   // Watch content field for real-time validation
   const content = watch("content");
-  const { charCount, wordCount, hasMinChars, hasMaxWords } = useContentValidation(content);
+  const { charCount, wordCount, hasMinChars, hasMaxWords } =
+    useContentValidation(content);
 
   // Fetch available agents
   useEffect(() => {
@@ -304,12 +328,12 @@ export default function CreateDocumentForm() {
         if (!response.ok) throw new Error("Failed to fetch agents");
         const data = await response.json();
         const fetchedAgents = data.agents || [];
-        
+
         // Sort agents: recommended first, then regular, then deprecated
         const sortedAgents = sortAgentsByBadgeStatus<Agent>(fetchedAgents);
         setAgents(sortedAgents);
       } catch (error) {
-        logger.error('Error fetching agents:', error);
+        logger.error("Error fetching agents:", error);
       } finally {
         setLoadingAgents(false);
       }
@@ -318,9 +342,9 @@ export default function CreateDocumentForm() {
   }, []);
 
   const toggleAgent = (agentId: string) => {
-    setSelectedAgentIds(prev => 
-      prev.includes(agentId) 
-        ? prev.filter(id => id !== agentId)
+    setSelectedAgentIds((prev) =>
+      prev.includes(agentId)
+        ? prev.filter((id) => id !== agentId)
         : [...prev, agentId]
     );
   };
@@ -359,7 +383,10 @@ export default function CreateDocumentForm() {
       if (error instanceof z.ZodError) {
         let hasFieldError = false;
         error.errors.forEach((err) => {
-          const field = typeof err.path?.[0] === "string" ? (err.path[0] as keyof DocumentInput) : undefined;
+          const field =
+            typeof err.path?.[0] === "string"
+              ? (err.path[0] as keyof DocumentInput)
+              : undefined;
           if (field) {
             setError(field, { message: err.message });
             hasFieldError = true;
@@ -369,7 +396,7 @@ export default function CreateDocumentForm() {
           setError("root", { message: "Please fix the validation errors." });
         }
       } else {
-        logger.error('Error submitting form:', error);
+        logger.error("Error submitting form:", error);
         setError("root", { message: "An unexpected error occurred" });
       }
     }
@@ -394,7 +421,7 @@ export default function CreateDocumentForm() {
               <button
                 type="button"
                 onClick={() => setMode("import")}
-                className={`flex-1 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                   mode === "import"
                     ? "bg-white text-gray-900 shadow-sm"
                     : "text-gray-600 hover:text-gray-900"
@@ -406,7 +433,7 @@ export default function CreateDocumentForm() {
               <button
                 type="button"
                 onClick={() => setMode("manual")}
-                className={`flex-1 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                   mode === "manual"
                     ? "bg-white text-gray-900 shadow-sm"
                     : "text-gray-600 hover:text-gray-900"
@@ -439,11 +466,15 @@ export default function CreateDocumentForm() {
                   disabled={isImporting}
                   className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                 />
+                <div className="mt-6 text-sm text-gray-600">
+                  Supports LessWrong and the EA Forum. Attempts to fetch article
+                  content from other platforms.
+                </div>
               </div>
 
-              <PrivacyToggle 
-                isPrivate={importIsPrivate} 
-                onChange={setImportIsPrivate} 
+              <PrivacyToggle
+                isPrivate={importIsPrivate}
+                onChange={setImportIsPrivate}
               />
 
               <AgentSelector
@@ -475,26 +506,18 @@ export default function CreateDocumentForm() {
 
               {isImporting && (
                 <div className="mt-4 text-center text-sm text-gray-600">
-                  Importing may take 10-20 seconds. Please be patient while we process
-                  your document.
+                  Importing may take 10-20 seconds. Please be patient while we
+                  process your document.
                 </div>
               )}
-
-              <div className="mt-6 text-sm text-gray-600">
-                <p>Supported platforms:</p>
-                <ul className="mt-2 list-inside list-disc space-y-1">
-                  <li>LessWrong</li>
-                  <li>EA Forum</li>
-                  <li>Medium</li>
-                  <li>Substack</li>
-                  <li>General web articles</li>
-                </ul>
-              </div>
             </form>
           ) : (
             // Manual Mode
             <FormProvider {...methods}>
-              <form onSubmit={methods.handleSubmit(onSubmit)} className="space-y-6">
+              <form
+                onSubmit={methods.handleSubmit(onSubmit)}
+                className="space-y-6"
+              >
                 <FormField
                   name="content"
                   label="Content"
@@ -511,20 +534,34 @@ export default function CreateDocumentForm() {
                     />
                     <div className="flex justify-between text-sm">
                       <div className="space-x-4">
-                        <span className={`${!hasMinChars && charCount > 0 ? "text-red-600" : "text-gray-500"}`}>
-                          {charCount} characters {!hasMinChars && charCount > 0 && `(min: ${CONTENT_MIN_CHARS})`}
+                        <span
+                          className={`${!hasMinChars && charCount > 0 ? "text-red-600" : "text-gray-500"}`}
+                        >
+                          {charCount} characters{" "}
+                          {!hasMinChars &&
+                            charCount > 0 &&
+                            `(min: ${CONTENT_MIN_CHARS})`}
                         </span>
-                        <span className={`${!hasMaxWords && wordCount > 0 ? "text-red-600" : "text-gray-500"}`}>
-                          {wordCount.toLocaleString()} words {!hasMaxWords && `(max: ${CONTENT_MAX_WORDS.toLocaleString()})`}
+                        <span
+                          className={`${!hasMaxWords && wordCount > 0 ? "text-red-600" : "text-gray-500"}`}
+                        >
+                          {wordCount.toLocaleString()} words{" "}
+                          {!hasMaxWords &&
+                            `(max: ${CONTENT_MAX_WORDS.toLocaleString()})`}
                         </span>
                       </div>
                       {content && (
                         <div>
                           {!hasMinChars && (
-                            <span className="text-red-600">Need {CONTENT_MIN_CHARS - charCount} more characters</span>
+                            <span className="text-red-600">
+                              Need {CONTENT_MIN_CHARS - charCount} more
+                              characters
+                            </span>
                           )}
                           {hasMinChars && hasMaxWords && (
-                            <span className="text-green-600">✓ Valid length</span>
+                            <span className="text-green-600">
+                              ✓ Valid length
+                            </span>
                           )}
                         </div>
                       )}
@@ -550,7 +587,7 @@ export default function CreateDocumentForm() {
                   </FormField>
                 ))}
 
-                <PrivacyToggle 
+                <PrivacyToggle
                   isPrivate={methods.watch("isPrivate") || false}
                   onChange={(value) => methods.setValue("isPrivate", value)}
                 />
@@ -566,7 +603,9 @@ export default function CreateDocumentForm() {
                 />
 
                 {errors.root && (
-                  <ErrorAlert message={errors.root.message || "An error occurred"} />
+                  <ErrorAlert
+                    message={errors.root.message || "An error occurred"}
+                  />
                 )}
 
                 <div className="flex justify-end gap-3">

--- a/apps/web/src/app/docs/new/CreateDocumentForm.tsx
+++ b/apps/web/src/app/docs/new/CreateDocumentForm.tsx
@@ -10,11 +10,14 @@ import { z } from "zod";
 import { Button } from "@/components/Button";
 import { FormField } from "@/components/FormField";
 import { AgentBadges } from "@/components/AgentBadges";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
 import { 
   LinkIcon, 
   DocumentTextIcon,
   CheckIcon,
   LockClosedIcon,
+  GlobeAltIcon,
 } from "@heroicons/react/24/outline";
 
 import { createDocument } from "./actions";
@@ -84,31 +87,32 @@ function PrivacyToggle({ isPrivate, onChange, useRegister }: PrivacyToggleProps)
       <label className="text-sm font-medium text-gray-900">
         Document Privacy
       </label>
-      <div className="bg-gray-50 rounded-lg p-4">
-        <label className="flex items-start gap-3 cursor-pointer">
-          {useRegister ? (
-            <input
-              {...useRegister}
-              type="checkbox"
-              className="mt-1 rounded text-indigo-600 focus:ring-indigo-500"
-            />
-          ) : (
-            <input
-              type="checkbox"
-              checked={isPrivate}
-              onChange={(e) => onChange(e.target.checked)}
-              className="mt-1 rounded text-indigo-600 focus:ring-indigo-500"
-            />
-          )}
-          <div className="flex items-start gap-2">
-            <LockClosedIcon className="h-5 w-5 text-gray-500 mt-0.5" />
+      <RadioGroup
+        value={isPrivate ? "private" : "public"}
+        onValueChange={(value: string) => onChange(value === "private")}
+        className="flex gap-6"
+      >
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="public" id="create-public" />
+          <Label htmlFor="create-public" className="flex items-center gap-2 cursor-pointer">
+            <GlobeAltIcon className="h-4 w-4 text-gray-500" />
             <div>
-              <div className="text-sm font-medium text-gray-900">Keep this document private</div>
-              <div className="text-xs text-gray-500">Only you will be able to view this document. Private by default.</div>
+              <div className="text-sm font-medium">Public</div>
+              <div className="text-xs text-gray-500">Anyone can view this document</div>
             </div>
-          </div>
-        </label>
-      </div>
+          </Label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="private" id="create-private" />
+          <Label htmlFor="create-private" className="flex items-center gap-2 cursor-pointer">
+            <LockClosedIcon className="h-4 w-4 text-gray-500" />
+            <div>
+              <div className="text-sm font-medium">Private</div>
+              <div className="text-xs text-gray-500">Only you can view this document</div>
+            </div>
+          </Label>
+        </div>
+      </RadioGroup>
     </div>
   );
 }
@@ -547,9 +551,8 @@ export default function CreateDocumentForm() {
                 ))}
 
                 <PrivacyToggle 
-                  isPrivate={true}
-                  onChange={() => {}}
-                  useRegister={methods.register("isPrivate")}
+                  isPrivate={methods.watch("isPrivate") || false}
+                  onChange={(value) => methods.setValue("isPrivate", value)}
                 />
 
                 <AgentSelector

--- a/apps/web/src/components/DocumentEvaluationSidebar.tsx
+++ b/apps/web/src/components/DocumentEvaluationSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { PenTool } from "lucide-react";
+import { Microscope } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -65,7 +65,7 @@ export function DocumentEvaluationSidebar({
       <div className="p-6">
         {/* Eval Editor Header */}
         <div className="mb-6 ml-2 flex cursor-default select-none items-center gap-2 text-sm font-semibold text-gray-500">
-          <PenTool className="h-5 w-5 text-gray-400" />
+          <Microscope className="h-5 w-5 text-gray-400" />
           {UI_LABELS.EVAL_EDITOR.label.toUpperCase()}
         </div>
         {/* Document Link */}

--- a/apps/web/src/components/DocumentEvaluationSidebar.tsx
+++ b/apps/web/src/components/DocumentEvaluationSidebar.tsx
@@ -2,22 +2,23 @@
 
 import { useState } from "react";
 
+import { PenTool } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { UI_LABELS } from "@/constants/ui-labels";
 import { getEvaluationGrade } from "@/shared/utils/type-guards";
 import {
   BeakerIcon,
   BookOpenIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  CommandLineIcon,
   DocumentTextIcon,
 } from "@heroicons/react/24/outline";
+import type { JobStatus } from "@roast/db";
 
 import { GradeBadge } from "./GradeBadge";
 import { JobStatusIndicator } from "./JobStatusIndicator";
-import type { JobStatus } from "@roast/db";
 
 interface Evaluation {
   id?: string;
@@ -60,12 +61,12 @@ export function DocumentEvaluationSidebar({
   const isReaderPage = pathname === `/docs/${docId}/reader`;
 
   return (
-    <nav className="h-full w-64 flex-shrink-0 overflow-y-auto border-r border-gray-200 bg-white">
+    <nav className="w-64 flex-shrink-0 overflow-y-auto border-r border-gray-200 bg-white">
       <div className="p-6">
-        {/* Inspector View Header */}
+        {/* Eval Editor Header */}
         <div className="mb-6 ml-2 flex cursor-default select-none items-center gap-2 text-sm font-semibold text-gray-500">
-          <CommandLineIcon className="h-5 w-5 text-gray-400" />
-          INSPECTOR VIEW
+          <PenTool className="h-5 w-5 text-gray-400" />
+          {UI_LABELS.EVAL_EDITOR.label.toUpperCase()}
         </div>
         {/* Document Link */}
         <Link
@@ -79,7 +80,6 @@ export function DocumentEvaluationSidebar({
           <DocumentTextIcon className="h-4 w-4" />
           Overview
         </Link>
-
 
         {/* Reader View Link */}
         <Link

--- a/apps/web/src/components/DocumentWithEvaluations/components/CommentToolbar.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/CommentToolbar.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { CheckIcon } from "@heroicons/react/20/solid";
+import { Maximize2, Minimize2, Download, Copy } from "lucide-react";
+
+interface CommentToolbarProps {
+  documentId: string;
+  isFullWidth: boolean;
+  onToggleFullWidth: () => void;
+}
+
+export function CommentToolbar({
+  documentId,
+  isFullWidth,
+  onToggleFullWidth,
+}: CommentToolbarProps) {
+  const [exportMode, setExportMode] = useState<'download' | 'clipboard'>('download');
+  const [copiedFormat, setCopiedFormat] = useState<string | null>(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const handleExport = useCallback(async (format: string) => {
+    if (exportMode === 'clipboard') {
+      try {
+        const response = await fetch(`/api/documents/${documentId}/export?format=${format}`);
+        const text = await response.text();
+        await navigator.clipboard.writeText(text);
+        
+        // Show success feedback
+        setCopiedFormat(format);
+        setTimeout(() => setCopiedFormat(null), 2000);
+      } catch (error) {
+        console.error('Failed to copy to clipboard:', error);
+      }
+    } else {
+      // Download mode - use existing anchor tag behavior
+      window.location.href = `/api/documents/${documentId}/export?format=${format}`;
+    }
+  }, [documentId, exportMode]);
+
+  // Reset to download mode when dropdown closes
+  const handleMouseLeave = useCallback(() => {
+    setDropdownOpen(false);
+    // Reset state after a small delay to allow for smooth transition
+    setTimeout(() => {
+      setExportMode('download');
+      setCopiedFormat(null);
+    }, 200);
+  }, []);
+
+  return (
+    <div className="flex items-center justify-end gap-2 mb-4">
+      <Button
+        onClick={onToggleFullWidth}
+        variant="outline"
+        size="sm"
+        title={isFullWidth ? "Exit full width" : "Enter full width"}
+      >
+        {isFullWidth ? (
+          <Minimize2 className="h-4 w-4" />
+        ) : (
+          <Maximize2 className="h-4 w-4" />
+        )}
+        <span className="hidden sm:inline">
+          {isFullWidth ? "Exit Full Width" : "Full Width"}
+        </span>
+      </Button>
+      
+      {/* Export dropdown */}
+      <div 
+        className="relative group"
+        onMouseEnter={() => setDropdownOpen(true)}
+        onMouseLeave={handleMouseLeave}
+      >
+        <Button
+          variant="outline"
+          size="sm"
+          title="Export document"
+        >
+          <Download className="h-4 w-4" />
+          <span className="hidden sm:inline">Export</span>
+        </Button>
+        <div className={`absolute right-0 mt-2 w-72 bg-white rounded-lg shadow-xl ring-1 ring-black ring-opacity-5 z-50 transition-all duration-200 ${
+          dropdownOpen ? 'opacity-100 visible' : 'opacity-0 invisible'
+        }`}>
+          {/* Mode toggle */}
+          <div className="p-3 border-b border-gray-200 bg-gray-50">
+            <div className="flex p-1 bg-white rounded-lg border border-gray-200">
+              <Button
+                onClick={() => setExportMode('download')}
+                variant={exportMode === 'download' ? 'default' : 'ghost'}
+                size="sm"
+                className="flex-1 justify-start"
+              >
+                <Download className="h-4 w-4" />
+                Save to file
+              </Button>
+              <Button
+                onClick={() => setExportMode('clipboard')}
+                variant={exportMode === 'clipboard' ? 'default' : 'ghost'}
+                size="sm"
+                className="flex-1 justify-start"
+              >
+                <Copy className="h-4 w-4" />
+                Copy to clipboard
+              </Button>
+            </div>
+          </div>
+          {/* Export options */}
+          <div className="py-2">
+            {exportMode === 'download' ? (
+              <>
+                <a
+                  href={`/api/documents/${documentId}/export?format=md`}
+                  download
+                  className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center">
+                    <span className="text-blue-600 text-xs font-bold">MD</span>
+                  </div>
+                  <span>Markdown</span>
+                </a>
+                <a
+                  href={`/api/documents/${documentId}/export?format=yaml`}
+                  download
+                  className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="w-8 h-8 bg-green-50 rounded-lg flex items-center justify-center">
+                    <span className="text-green-600 text-xs font-bold">YML</span>
+                  </div>
+                  <span>YAML</span>
+                </a>
+                <a
+                  href={`/api/documents/${documentId}/export?format=json`}
+                  download
+                  className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="w-8 h-8 bg-orange-50 rounded-lg flex items-center justify-center">
+                    <span className="text-orange-600 text-xs font-bold">JSON</span>
+                  </div>
+                  <span>JSON</span>
+                </a>
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => handleExport('md')}
+                  className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center">
+                      <span className="text-blue-600 text-xs font-bold">MD</span>
+                    </div>
+                    <span>Markdown</span>
+                  </div>
+                  {copiedFormat === 'md' && (
+                    <CheckIcon className="h-5 w-5 text-green-600" />
+                  )}
+                </button>
+                <button
+                  onClick={() => handleExport('yaml')}
+                  className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-green-50 rounded-lg flex items-center justify-center">
+                      <span className="text-green-600 text-xs font-bold">YML</span>
+                    </div>
+                    <span>YAML</span>
+                  </div>
+                  {copiedFormat === 'yaml' && (
+                    <CheckIcon className="h-5 w-5 text-green-600" />
+                  )}
+                </button>
+                <button
+                  onClick={() => handleExport('json')}
+                  className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-orange-50 rounded-lg flex items-center justify-center">
+                      <span className="text-orange-600 text-xs font-bold">JSON</span>
+                    </div>
+                    <span>JSON</span>
+                  </div>
+                  {copiedFormat === 'json' && (
+                    <CheckIcon className="h-5 w-5 text-green-600" />
+                  )}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/DocumentWithEvaluations/components/DocumentContent.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/DocumentContent.tsx
@@ -20,7 +20,6 @@ interface DocumentContentProps {
   onHighlightHover: (commentId: string | null) => void;
   onHighlightClick: (commentId: string) => void;
   isFullWidth: boolean;
-  onToggleFullWidth: () => void;
   contentRef: RefObject<HTMLDivElement | null>;
 }
 
@@ -32,7 +31,6 @@ export function DocumentContent({
   onHighlightHover,
   onHighlightClick,
   isFullWidth,
-  onToggleFullWidth,
   contentRef,
 }: DocumentContentProps) {
   return (
@@ -49,8 +47,6 @@ export function DocumentContent({
       <DocumentMetadata
         document={document}
         showDetailedAnalysisLink={true}
-        isFullWidth={isFullWidth}
-        onToggleFullWidth={onToggleFullWidth}
       />
 
       <article

--- a/apps/web/src/components/DocumentWithEvaluations/components/DocumentMetadata.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/DocumentMetadata.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { ExternalLink, Microscope } from "lucide-react";
 import Link from "next/link";
 
-import type { Document } from "@/shared/types/databaseTypes";
 import { PrivacyBadge } from "@/components/PrivacyBadge";
-import { ROUTES } from "@/constants/routes";
 import { Button } from "@/components/ui/button";
-import { PenTool, ExternalLink } from "lucide-react";
+import { ROUTES } from "@/constants/routes";
 import { UI_LABELS } from "@/constants/ui-labels";
+import type { Document } from "@/shared/types/databaseTypes";
 
 interface DocumentMetadataProps {
   document: Document;
@@ -41,24 +41,18 @@ export function DocumentMetadata({
         )}
       </div>
       <div className="flex items-center gap-2">
-        <Button
-          asChild
-          variant="outline"
-          size="sm"
-        >
+        <Button asChild variant="outline" size="sm">
           <Link href={`/docs/${document.id}`}>
-            <PenTool className="h-4 w-4" />
+            <Microscope className="h-4 w-4" />
             <span className="hidden sm:inline">
-              {showDetailedAnalysisLink ? UI_LABELS.EVAL_EDITOR.label : "Document Details"}
+              {showDetailedAnalysisLink
+                ? UI_LABELS.EVAL_EDITOR.label
+                : "Document Details"}
             </span>
           </Link>
         </Button>
         {(document.importUrl || document.url) && (
-          <Button
-            asChild
-            variant="outline"
-            size="sm"
-          >
+          <Button asChild variant="outline" size="sm">
             <Link
               href={document.importUrl || document.url || ""}
               target="_blank"

--- a/apps/web/src/components/DocumentWithEvaluations/components/DocumentMetadata.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/DocumentMetadata.tsx
@@ -1,65 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useCallback } from "react";
 
 import type { Document } from "@/shared/types/databaseTypes";
 import { PrivacyBadge } from "@/components/PrivacyBadge";
 import { ROUTES } from "@/constants/routes";
-import {
-  ArrowsPointingInIcon,
-  ArrowsPointingOutIcon,
-  ArrowTopRightOnSquareIcon,
-  ArrowDownTrayIcon,
-  ClipboardDocumentIcon,
-  CheckIcon,
-} from "@heroicons/react/20/solid";
+import { Button } from "@/components/ui/button";
+import { PenTool, ExternalLink } from "lucide-react";
+import { UI_LABELS } from "@/constants/ui-labels";
 
 interface DocumentMetadataProps {
   document: Document;
   showDetailedAnalysisLink?: boolean;
-  isFullWidth?: boolean;
-  onToggleFullWidth?: () => void;
 }
 
 export function DocumentMetadata({
   document,
   showDetailedAnalysisLink = false,
-  isFullWidth = false,
-  onToggleFullWidth,
 }: DocumentMetadataProps) {
-  const [exportMode, setExportMode] = useState<'download' | 'clipboard'>('download');
-  const [copiedFormat, setCopiedFormat] = useState<string | null>(null);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-
-  const handleExport = useCallback(async (format: string) => {
-    if (exportMode === 'clipboard') {
-      try {
-        const response = await fetch(`/api/documents/${document.id}/export?format=${format}`);
-        const text = await response.text();
-        await navigator.clipboard.writeText(text);
-        
-        // Show success feedback
-        setCopiedFormat(format);
-        setTimeout(() => setCopiedFormat(null), 2000);
-      } catch (error) {
-        console.error('Failed to copy to clipboard:', error);
-      }
-    } else {
-      // Download mode - use existing anchor tag behavior
-      window.location.href = `/api/documents/${document.id}/export?format=${format}`;
-    }
-  }, [document.id, exportMode]);
-
-  // Reset to download mode when dropdown closes
-  const handleMouseLeave = useCallback(() => {
-    setDropdownOpen(false);
-    // Reset state after a small delay to allow for smooth transition
-    setTimeout(() => {
-      setExportMode('download');
-      setCopiedFormat(null);
-    }, 200);
-  }, []);
   return (
     <div className="flex items-center justify-between px-3">
       <div className="flex items-center gap-4 text-sm text-gray-600">
@@ -83,163 +41,33 @@ export function DocumentMetadata({
         )}
       </div>
       <div className="flex items-center gap-2">
-        {onToggleFullWidth && (
-          <button
-            onClick={onToggleFullWidth}
-            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-            title={isFullWidth ? "Exit full width" : "Enter full width"}
-          >
-            {isFullWidth ? (
-              <ArrowsPointingInIcon className="h-4 w-4" />
-            ) : (
-              <ArrowsPointingOutIcon className="h-4 w-4" />
-            )}
-            {isFullWidth ? "Exit Full Width" : "Full Width"}
-          </button>
-        )}
-        <Link
-          href={`/docs/${document.id}`}
-          className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
+        <Button
+          asChild
+          variant="outline"
+          size="sm"
         >
-          {showDetailedAnalysisLink ? "Detailed Analysis" : "Document Details"}
-        </Link>
-        {(document.importUrl || document.url) && (
-          <Link
-            href={document.importUrl || document.url || ""}
-            target="_blank"
-            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-          >
-            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-            Source
+          <Link href={`/docs/${document.id}`}>
+            <PenTool className="h-4 w-4" />
+            <span className="hidden sm:inline">
+              {showDetailedAnalysisLink ? UI_LABELS.EVAL_EDITOR.label : "Document Details"}
+            </span>
           </Link>
-        )}
-        {/* Export dropdown */}
-        <div 
-          className="relative group"
-          onMouseEnter={() => setDropdownOpen(true)}
-          onMouseLeave={handleMouseLeave}
-        >
-          <button
-            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-300"
-            title="Export document"
+        </Button>
+        {(document.importUrl || document.url) && (
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
           >
-            <ArrowDownTrayIcon className="h-4 w-4" />
-            Export
-          </button>
-          <div className={`absolute right-0 mt-2 w-72 bg-white rounded-lg shadow-xl ring-1 ring-black ring-opacity-5 z-10 transition-all duration-200 ${
-            dropdownOpen ? 'opacity-100 visible' : 'opacity-0 invisible'
-          }`}>
-            {/* Mode toggle */}
-            <div className="p-3 border-b border-gray-200 bg-gray-50">
-              <div className="flex p-1 bg-white rounded-lg border border-gray-200">
-                <button
-                  onClick={() => setExportMode('download')}
-                  className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-md text-sm font-medium transition-all duration-200 ${
-                    exportMode === 'download' 
-                      ? 'bg-slate-700 text-white shadow-sm' 
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
-                  }`}
-                >
-                  <ArrowDownTrayIcon className="h-4 w-4" />
-                  Save to file
-                </button>
-                <button
-                  onClick={() => setExportMode('clipboard')}
-                  className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-md text-sm font-medium transition-all duration-200 ${
-                    exportMode === 'clipboard' 
-                      ? 'bg-slate-700 text-white shadow-sm' 
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
-                  }`}
-                >
-                  <ClipboardDocumentIcon className="h-4 w-4" />
-                  Copy to clipboard
-                </button>
-              </div>
-            </div>
-            {/* Export options */}
-            <div className="py-2">
-              {exportMode === 'download' ? (
-                <>
-                  <a
-                    href={`/api/documents/${document.id}/export?format=md`}
-                    download
-                    className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center">
-                      <span className="text-blue-600 text-xs font-bold">MD</span>
-                    </div>
-                    <span>Markdown</span>
-                  </a>
-                  <a
-                    href={`/api/documents/${document.id}/export?format=yaml`}
-                    download
-                    className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="w-8 h-8 bg-green-50 rounded-lg flex items-center justify-center">
-                      <span className="text-green-600 text-xs font-bold">YML</span>
-                    </div>
-                    <span>YAML</span>
-                  </a>
-                  <a
-                    href={`/api/documents/${document.id}/export?format=json`}
-                    download
-                    className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="w-8 h-8 bg-orange-50 rounded-lg flex items-center justify-center">
-                      <span className="text-orange-600 text-xs font-bold">JSON</span>
-                    </div>
-                    <span>JSON</span>
-                  </a>
-                </>
-              ) : (
-                <>
-                  <button
-                    onClick={() => handleExport('md')}
-                    className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center">
-                        <span className="text-blue-600 text-xs font-bold">MD</span>
-                      </div>
-                      <span>Markdown</span>
-                    </div>
-                    {copiedFormat === 'md' && (
-                      <CheckIcon className="h-5 w-5 text-green-600" />
-                    )}
-                  </button>
-                  <button
-                    onClick={() => handleExport('yaml')}
-                    className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 bg-green-50 rounded-lg flex items-center justify-center">
-                        <span className="text-green-600 text-xs font-bold">YML</span>
-                      </div>
-                      <span>YAML</span>
-                    </div>
-                    {copiedFormat === 'yaml' && (
-                      <CheckIcon className="h-5 w-5 text-green-600" />
-                    )}
-                  </button>
-                  <button
-                    onClick={() => handleExport('json')}
-                    className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 bg-orange-50 rounded-lg flex items-center justify-center">
-                        <span className="text-orange-600 text-xs font-bold">JSON</span>
-                      </div>
-                      <span>JSON</span>
-                    </div>
-                    {copiedFormat === 'json' && (
-                      <CheckIcon className="h-5 w-5 text-green-600" />
-                    )}
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+            <Link
+              href={document.importUrl || document.url || ""}
+              target="_blank"
+            >
+              <ExternalLink className="h-4 w-4" />
+              <span className="hidden sm:inline">Source</span>
+            </Link>
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/DocumentWithEvaluations/components/EvaluationView.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/EvaluationView.tsx
@@ -18,6 +18,7 @@ import { LAYOUT } from "../constants";
 import { useScrollBehavior } from "../hooks/useScrollBehavior";
 import { EvaluationViewProps } from "../types";
 import { CommentsColumn } from "./CommentsColumn";
+import { CommentToolbar } from "./CommentToolbar";
 import { DocumentContent } from "./DocumentContent";
 import { EvaluationAnalysisSection } from "./EvaluationAnalysisSection";
 import { EvaluationCardsHeader } from "./EvaluationCardsHeader";
@@ -191,7 +192,6 @@ export function EvaluationView({
                 });
               }}
               isFullWidth={isFullWidth}
-              onToggleFullWidth={() => setIsFullWidth(!isFullWidth)}
               contentRef={contentRef}
             />
             {/* Comments column with filters and positioned comments */}
@@ -202,6 +202,11 @@ export function EvaluationView({
                 marginLeft: "2rem",
               }}
             >
+              <CommentToolbar
+                documentId={document.id}
+                isFullWidth={isFullWidth}
+                onToggleFullWidth={() => setIsFullWidth(!isFullWidth)}
+              />
               <CommentsColumn
                 comments={displayComments}
                 contentRef={contentRef}

--- a/apps/web/src/components/EvaluationCard/shared/EvaluationActions.tsx
+++ b/apps/web/src/components/EvaluationCard/shared/EvaluationActions.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ArrowPathIcon, CommandLineIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { Button } from "@/components/ui/button";
 
 interface EvaluationActionsProps {
   documentId: string;
@@ -38,48 +39,47 @@ export function EvaluationActions({
   return (
     <div className={className}>
       {showRerun && onRerun && (
-        <button
+        <Button
           onClick={onRerun}
           disabled={isRunning}
-          className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          variant="outline"
+          size="sm"
         >
           <ArrowPathIcon className={`h-3.5 w-3.5 ${isRunning ? 'animate-spin' : ''}`} />
           {isRunning ? 'Running...' : 'Rerun'}
-        </button>
+        </Button>
       )}
       {showDelete && onDelete && (
-        <button
+        <Button
           onClick={onDelete}
           disabled={isDeleting}
-          className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-red-600 bg-white border border-red-200 rounded-md hover:bg-red-50 hover:border-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          variant="outline"
+          size="sm"
+          className="text-red-600 hover:text-red-700 hover:bg-red-50"
         >
           <TrashIcon className={`h-3.5 w-3.5 ${isDeleting ? 'animate-pulse' : ''}`} />
           {isDeleting ? 'Deleting...' : 'Delete'}
-        </button>
+        </Button>
       )}
       {showDetails && (
-        <Link
-          href={`/docs/${documentId}/evals/${agentId}`}
-          className={
-            detailsStyle === "button"
-              ? "inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-purple-600 rounded-md hover:bg-purple-700 transition-colors"
-              : "flex items-center text-xs font-medium text-gray-400 hover:text-gray-700 hover:underline"
-          }
-        >
-          {detailsStyle === "button" ? (
-            <>
+        detailsStyle === "button" ? (
+          <Button asChild size="sm">
+            <Link href={`/docs/${documentId}/evals/${agentId}`}>
               <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
               {detailsText}
-            </>
-          ) : (
-            <>
-              <CommandLineIcon className="mr-1 h-4 w-4" />
-              {detailsText}
-            </>
-          )}
-        </Link>
+            </Link>
+          </Button>
+        ) : (
+          <Link
+            href={`/docs/${documentId}/evals/${agentId}`}
+            className="flex items-center text-xs font-medium text-gray-400 hover:text-gray-700 hover:underline"
+          >
+            <CommandLineIcon className="mr-1 h-4 w-4" />
+            {detailsText}
+          </Link>
+        )
       )}
     </div>
   );

--- a/apps/web/src/components/EvaluationCard/shared/EvaluationStats.tsx
+++ b/apps/web/src/components/EvaluationCard/shared/EvaluationStats.tsx
@@ -46,7 +46,7 @@ export function EvaluationStats({
       <Link
         key="versions"
         href={`/docs/${docId}/evals/${agentId}/versions/${versionNumber || versionCount}`}
-        className="text-purple-700 hover:text-purple-900"
+        className="text-blue-600 hover:text-blue-800"
       >
         {versionCount} version{versionCount !== 1 ? "s" : ""}
       </Link>

--- a/apps/web/src/components/ExportEvaluationButton.tsx
+++ b/apps/web/src/components/ExportEvaluationButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ClipboardDocumentIcon } from "@heroicons/react/24/outline";
 import { CheckIcon } from "@heroicons/react/24/solid";
+import { Button } from "@/components/ui/button";
 import { exportEvaluationToXml, copyToClipboard } from "@/application/workflows/evaluation/exportXml";
 
 interface ExportEvaluationButtonProps {
@@ -62,13 +63,11 @@ export function ExportEvaluationButton({ evaluationData, className = "" }: Expor
     }
   };
 
-  const baseClassName = "inline-flex items-center gap-2 rounded-md bg-gray-600 px-3 py-2 text-sm font-medium text-white hover:bg-gray-700";
-  const combinedClassName = className ? `${baseClassName} ${className}` : baseClassName;
-
   return (
-    <button
+    <Button
       onClick={handleExportToXml}
-      className={combinedClassName}
+      variant="secondary"
+      className={className}
     >
       {copied ? (
         <>
@@ -81,6 +80,6 @@ export function ExportEvaluationButton({ evaluationData, className = "" }: Expor
           Export to XML
         </>
       )}
-    </button>
+    </Button>
   );
 }

--- a/apps/web/src/components/RerunButtonClient.tsx
+++ b/apps/web/src/components/RerunButtonClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import { rerunEvaluation, createOrRerunEvaluation } from "@/app/docs/[docId]/actions/evaluation-actions";
 
 interface RerunButtonClientProps {
@@ -60,12 +61,11 @@ export function RerunButtonClient({
   }
 
   return (
-    <button
+    <Button
       onClick={handleRerun}
       disabled={isLoading}
-      className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
     >
       {isLoading ? "Triggering..." : "Rerun"}
-    </button>
+    </Button>
   );
 }

--- a/apps/web/src/components/evaluation/EvaluationDetailsSection.tsx
+++ b/apps/web/src/components/evaluation/EvaluationDetailsSection.tsx
@@ -1,21 +1,29 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
 import { Bot } from "lucide-react";
-import { GradeBadge } from "@/components/GradeBadge";
+import Link from "next/link";
+
+import {
+  formatCostFromDollars,
+  formatDate,
+  formatDuration,
+} from "@/application/services/job/formatters";
 import { ExperimentalBadge } from "@/components/ExperimentalBadge";
-import { EvaluationSection } from "./EvaluationSection";
-import { formatCostFromDollars, formatDuration, formatDate } from "@/application/services/job/formatters";
-import { 
-  ClipboardDocumentIcon, 
+import { GradeBadge } from "@/components/GradeBadge";
+import { Button } from "@/components/ui/button";
+import {
   ArrowDownTrayIcon,
+  BookOpenIcon,
+  ChartBarIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  BookOpenIcon,
-  ChartBarIcon
+  ClipboardDocumentIcon,
 } from "@heroicons/react/24/outline";
 import { CheckIcon } from "@heroicons/react/24/solid";
+
+import { EvaluationSection } from "./EvaluationSection";
 
 interface EvaluationDetailsSectionProps {
   agentName: string;
@@ -35,8 +43,8 @@ interface EvaluationDetailsSectionProps {
   isOnEvalPage?: boolean;
 }
 
-type ExportFormat = 'json' | 'yaml' | 'markdown';
-type ExportDestination = 'clipboard' | 'file';
+type ExportFormat = "json" | "yaml" | "markdown";
+type ExportDestination = "clipboard" | "file";
 
 export function EvaluationDetailsSection({
   agentName,
@@ -50,7 +58,7 @@ export function EvaluationDetailsSection({
   evaluationData,
   documentId,
   evaluationId,
-  isOnEvalPage = false
+  isOnEvalPage = false,
 }: EvaluationDetailsSectionProps) {
   const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
@@ -61,18 +69,25 @@ export function EvaluationDetailsSection({
   // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setExportDropdownOpen(false);
       }
     }
 
     if (exportDropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
     }
   }, [exportDropdownOpen]);
 
-  const handleExport = async (format: ExportFormat, destination: ExportDestination) => {
+  const handleExport = async (
+    format: ExportFormat,
+    destination: ExportDestination
+  ) => {
     if (!evaluationData) return;
 
     // Create export data with only the current/latest version
@@ -92,72 +107,77 @@ export function EvaluationDetailsSection({
         grade: latestVersion?.grade,
         selfCritique: latestVersion?.selfCritique,
         comments: latestVersion?.comments || [],
-        llmThinking: job?.llmThinking
+        llmThinking: job?.llmThinking,
       },
-      job: job ? {
-        id: job.id,
-        status: job.status,
-        priceInDollars: job.priceInDollars,
-        durationInSeconds: job.durationInSeconds,
-        llmModel: job.llmModel,
-        inputTokens: job.inputTokens,
-        outputTokens: job.outputTokens,
-        createdAt: job.createdAt,
-        updatedAt: job.updatedAt,
-        startedAt: job.startedAt,
-        completedAt: job.completedAt,
-        attempts: job.attempts,
-        error: job.error,
-        logs: job.logs,
-        llmThinking: job.llmThinking
-      } : null,
+      job: job
+        ? {
+            id: job.id,
+            status: job.status,
+            priceInDollars: job.priceInDollars,
+            durationInSeconds: job.durationInSeconds,
+            llmModel: job.llmModel,
+            inputTokens: job.inputTokens,
+            outputTokens: job.outputTokens,
+            createdAt: job.createdAt,
+            updatedAt: job.updatedAt,
+            startedAt: job.startedAt,
+            completedAt: job.completedAt,
+            attempts: job.attempts,
+            error: job.error,
+            logs: job.logs,
+            llmThinking: job.llmThinking,
+          }
+        : null,
       agent: {
         id: evaluationData.agent?.id,
-        name: evaluationData.agent?.versions?.[0]?.name || evaluationData.agentName,
-        description: evaluationData.agent?.versions?.[0]?.description || evaluationData.agentDescription
+        name:
+          evaluationData.agent?.versions?.[0]?.name || evaluationData.agentName,
+        description:
+          evaluationData.agent?.versions?.[0]?.description ||
+          evaluationData.agentDescription,
       },
       document: {
-        id: evaluationData.documentId
-      }
+        id: evaluationData.documentId,
+      },
     };
 
-    let content = '';
-    let filename = '';
-    let mimeType = '';
+    let content = "";
+    let filename = "";
+    let mimeType = "";
 
     // Generate content based on format
     switch (format) {
-      case 'json':
+      case "json":
         content = JSON.stringify(exportData, null, 2);
-        filename = `evaluation-${exportData.evaluation.id || 'export'}.json`;
-        mimeType = 'application/json';
+        filename = `evaluation-${exportData.evaluation.id || "export"}.json`;
+        mimeType = "application/json";
         break;
-      case 'yaml':
+      case "yaml":
         // Simple YAML serialization (could use a proper YAML library)
         content = jsonToYaml(exportData);
-        filename = `evaluation-${exportData.evaluation.id || 'export'}.yaml`;
-        mimeType = 'text/yaml';
+        filename = `evaluation-${exportData.evaluation.id || "export"}.yaml`;
+        mimeType = "text/yaml";
         break;
-      case 'markdown':
+      case "markdown":
         content = evaluationToMarkdown(exportData);
-        filename = `evaluation-${exportData.evaluation.id || 'export'}.md`;
-        mimeType = 'text/markdown';
+        filename = `evaluation-${exportData.evaluation.id || "export"}.md`;
+        mimeType = "text/markdown";
         break;
     }
 
-    if (destination === 'clipboard') {
+    if (destination === "clipboard") {
       try {
         await navigator.clipboard.writeText(content);
         setCopied(`${format}-clipboard`);
         setTimeout(() => setCopied(null), 2000);
       } catch (err) {
-        console.error('Failed to copy to clipboard:', err);
+        console.error("Failed to copy to clipboard:", err);
       }
     } else {
       // Download as file
       const blob = new Blob([content], { type: mimeType });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
       a.download = filename;
       document.body.appendChild(a);
@@ -171,15 +191,16 @@ export function EvaluationDetailsSection({
 
   // Truncate description if needed
   const shouldTruncate = agentDescription && agentDescription.length > 150;
-  const displayDescription = shouldTruncate && !descriptionExpanded 
-    ? agentDescription.substring(0, 150) + '...' 
-    : agentDescription;
+  const displayDescription =
+    shouldTruncate && !descriptionExpanded
+      ? agentDescription.substring(0, 150) + "..."
+      : agentDescription;
 
   return (
     <EvaluationSection id="evaluation-details" title="Evaluation Details">
       <div className="space-y-6">
         {/* Agent Information and Statistics Row */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           {/* Agent Information */}
           <div className="lg:col-span-2">
             <div className="flex items-start gap-4">
@@ -187,40 +208,42 @@ export function EvaluationDetailsSection({
               <div className="flex-shrink-0">
                 <Bot className="h-8 w-8 text-gray-600" />
               </div>
-              
+
               {/* Agent Details */}
               <div className="flex-1">
-                <div className="flex items-center gap-3 mb-2">
+                <div className="mb-2 flex items-center gap-3">
                   {agentId ? (
                     <Link href={`/agents/${agentId}`}>
-                      <h3 className="text-lg font-semibold text-gray-900 hover:text-gray-700 hover:underline cursor-pointer">
+                      <h3 className="cursor-pointer text-lg font-semibold text-gray-900 hover:text-gray-700 hover:underline">
                         {agentName}
                       </h3>
                     </Link>
                   ) : (
-                    <h3 className="text-lg font-semibold text-gray-900">{agentName}</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">
+                      {agentName}
+                    </h3>
                   )}
                   {grade !== undefined && grade !== null && (
                     <GradeBadge grade={grade} variant="dark" size="sm" />
                   )}
                   {ephemeralBatch && ephemeralBatch.trackingId && (
-                    <ExperimentalBadge 
-                      trackingId={ephemeralBatch.trackingId}
-                    />
+                    <ExperimentalBadge trackingId={ephemeralBatch.trackingId} />
                   )}
                 </div>
-                
+
                 {agentDescription && (
                   <div>
-                    <p className="text-sm text-gray-600 leading-relaxed">
+                    <p className="text-sm leading-relaxed text-gray-600">
                       {displayDescription}
                     </p>
                     {shouldTruncate && (
                       <button
-                        onClick={() => setDescriptionExpanded(!descriptionExpanded)}
-                        className="text-sm text-blue-600 hover:text-blue-800 mt-1"
+                        onClick={() =>
+                          setDescriptionExpanded(!descriptionExpanded)
+                        }
+                        className="mt-1 text-sm text-blue-600 hover:text-blue-800"
                       >
-                        {descriptionExpanded ? 'Show less' : 'Show more'}
+                        {descriptionExpanded ? "Show less" : "Show more"}
                       </button>
                     )}
                   </div>
@@ -231,28 +254,37 @@ export function EvaluationDetailsSection({
 
           {/* Run Statistics */}
           <div className="lg:border-l lg:border-gray-200 lg:pl-6">
-            <h4 className="text-sm font-medium text-gray-700 mb-4">Run Statistics</h4>
+            <h4 className="mb-4 text-sm font-medium text-gray-700">
+              Run Statistics
+            </h4>
             <dl className="space-y-3">
-              {durationInSeconds !== undefined && durationInSeconds !== null && (
-                <div>
-                  <dt className="text-xs text-gray-500 uppercase tracking-wide">Duration</dt>
-                  <dd className="text-sm font-medium text-gray-900 mt-1">
-                    {formatDuration(durationInSeconds)}
-                  </dd>
-                </div>
-              )}
+              {durationInSeconds !== undefined &&
+                durationInSeconds !== null && (
+                  <div>
+                    <dt className="text-xs uppercase tracking-wide text-gray-500">
+                      Duration
+                    </dt>
+                    <dd className="mt-1 text-sm font-medium text-gray-900">
+                      {formatDuration(durationInSeconds)}
+                    </dd>
+                  </div>
+                )}
               {priceInDollars !== undefined && priceInDollars !== null && (
                 <div>
-                  <dt className="text-xs text-gray-500 uppercase tracking-wide">Cost</dt>
-                  <dd className="text-sm font-medium text-gray-900 mt-1">
+                  <dt className="text-xs uppercase tracking-wide text-gray-500">
+                    Cost
+                  </dt>
+                  <dd className="mt-1 text-sm font-medium text-gray-900">
                     {formatCostFromDollars(priceInDollars)}
                   </dd>
                 </div>
               )}
               {createdAt && (
                 <div>
-                  <dt className="text-xs text-gray-500 uppercase tracking-wide">Created</dt>
-                  <dd className="text-sm font-medium text-gray-900 mt-1">
+                  <dt className="text-xs uppercase tracking-wide text-gray-500">
+                    Created
+                  </dt>
+                  <dd className="mt-1 text-sm font-medium text-gray-900">
                     {formatDate(createdAt)}
                   </dd>
                 </div>
@@ -269,21 +301,19 @@ export function EvaluationDetailsSection({
               {documentId && agentId && (
                 <>
                   {!isOnEvalPage && (
-                    <Link 
-                      href={`/docs/${documentId}/evals/${agentId}`}
-                      className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
-                    >
-                      <ChartBarIcon className="h-4 w-4" />
-                      Eval Details
-                    </Link>
+                    <Button asChild>
+                      <Link href={`/docs/${documentId}/evals/${agentId}`}>
+                        <ChartBarIcon className="h-4 w-4" />
+                        Eval Details
+                      </Link>
+                    </Button>
                   )}
-                  <Link 
-                    href={`/docs/${documentId}/reader?evals=${agentId}`}
-                    className="inline-flex items-center gap-2 rounded-md bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700 transition-colors"
-                  >
-                    <BookOpenIcon className="h-4 w-4" />
-                    Reader
-                  </Link>
+                  <Button asChild>
+                    <Link href={`/docs/${documentId}/reader?evals=${agentId}`}>
+                      <BookOpenIcon className="h-4 w-4" />
+                      Open in Reader
+                    </Link>
+                  </Button>
                 </>
               )}
             </div>
@@ -291,7 +321,7 @@ export function EvaluationDetailsSection({
             {/* Right side - Export button */}
             {evaluationData && (
               <div className="relative z-40">
-                <button
+                <Button
                   onClick={(e) => {
                     const rect = e.currentTarget.getBoundingClientRect();
                     setButtonRect(rect);
@@ -300,7 +330,7 @@ export function EvaluationDetailsSection({
                   aria-expanded={exportDropdownOpen}
                   aria-haspopup="menu"
                   aria-label="Export evaluation data"
-                  className="inline-flex items-center gap-2 rounded-md bg-gray-600 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition-colors"
+                  variant="outline"
                 >
                   <ArrowDownTrayIcon className="h-4 w-4" />
                   Export
@@ -309,59 +339,65 @@ export function EvaluationDetailsSection({
                   ) : (
                     <ChevronDownIcon className="h-4 w-4" />
                   )}
-                </button>
+                </Button>
 
-              {exportDropdownOpen && buttonRect && (
-                <div 
-                  ref={dropdownRef}
-                  role="menu"
-                  aria-label="Export options"
-                  className="fixed w-56 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 z-50"
-                  style={{
-                    top: buttonRect.bottom + 8,
-                    left: buttonRect.right - 224, // 224px = w-56 (14rem * 16px)
-                  }}
-                >
-                  <div className="py-1">
-                    <div className="px-3 py-2 text-xs font-medium text-gray-500 border-b">
-                      To Clipboard
+                {exportDropdownOpen && buttonRect && (
+                  <div
+                    ref={dropdownRef}
+                    role="menu"
+                    aria-label="Export options"
+                    className="fixed z-50 w-56 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5"
+                    style={{
+                      top: buttonRect.bottom + 8,
+                      left: buttonRect.right - 224, // 224px = w-56 (14rem * 16px)
+                    }}
+                  >
+                    <div className="py-1">
+                      <div className="border-b px-3 py-2 text-xs font-medium text-gray-500">
+                        To Clipboard
+                      </div>
+                      {(["json", "yaml", "markdown"] as ExportFormat[]).map(
+                        (format) => (
+                          <button
+                            key={`${format}-clipboard`}
+                            onClick={() => handleExport(format, "clipboard")}
+                            role="menuitem"
+                            className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                          >
+                            {copied === `${format}-clipboard` ? (
+                              <CheckIcon className="mr-2 h-4 w-4 text-green-600" />
+                            ) : (
+                              <ClipboardDocumentIcon className="mr-2 h-4 w-4" />
+                            )}
+                            {format.toUpperCase()}
+                            {copied === `${format}-clipboard` && (
+                              <span className="ml-auto text-green-600">
+                                Copied!
+                              </span>
+                            )}
+                          </button>
+                        )
+                      )}
+
+                      <div className="border-b border-t px-3 py-2 text-xs font-medium text-gray-500">
+                        Download File
+                      </div>
+                      {(["json", "yaml", "markdown"] as ExportFormat[]).map(
+                        (format) => (
+                          <button
+                            key={`${format}-file`}
+                            onClick={() => handleExport(format, "file")}
+                            role="menuitem"
+                            className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                          >
+                            <ArrowDownTrayIcon className="mr-2 h-4 w-4" />
+                            {format.toUpperCase()}
+                          </button>
+                        )
+                      )}
                     </div>
-                    {(['json', 'yaml', 'markdown'] as ExportFormat[]).map((format) => (
-                      <button
-                        key={`${format}-clipboard`}
-                        onClick={() => handleExport(format, 'clipboard')}
-                        role="menuitem"
-                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                      >
-                        {copied === `${format}-clipboard` ? (
-                          <CheckIcon className="h-4 w-4 mr-2 text-green-600" />
-                        ) : (
-                          <ClipboardDocumentIcon className="h-4 w-4 mr-2" />
-                        )}
-                        {format.toUpperCase()}
-                        {copied === `${format}-clipboard` && (
-                          <span className="ml-auto text-green-600">Copied!</span>
-                        )}
-                      </button>
-                    ))}
-                    
-                    <div className="px-3 py-2 text-xs font-medium text-gray-500 border-t border-b">
-                      Download File
-                    </div>
-                    {(['json', 'yaml', 'markdown'] as ExportFormat[]).map((format) => (
-                      <button
-                        key={`${format}-file`}
-                        onClick={() => handleExport(format, 'file')}
-                        role="menuitem"
-                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                      >
-                        <ArrowDownTrayIcon className="h-4 w-4 mr-2" />
-                        {format.toUpperCase()}
-                      </button>
-                    ))}
                   </div>
-                </div>
-              )}
+                )}
               </div>
             )}
           </div>
@@ -373,25 +409,25 @@ export function EvaluationDetailsSection({
 
 // Simple JSON to YAML converter (basic implementation)
 function jsonToYaml(obj: any, indent = 0): string {
-  const spaces = '  '.repeat(indent);
-  let result = '';
+  const spaces = "  ".repeat(indent);
+  let result = "";
 
   if (Array.isArray(obj)) {
     for (const item of obj) {
       result += `${spaces}- `;
-      if (typeof item === 'object' && item !== null) {
-        result += '\n' + jsonToYaml(item, indent + 1);
+      if (typeof item === "object" && item !== null) {
+        result += "\n" + jsonToYaml(item, indent + 1);
       } else {
-        result += yamlValue(item) + '\n';
+        result += yamlValue(item) + "\n";
       }
     }
-  } else if (typeof obj === 'object' && obj !== null) {
+  } else if (typeof obj === "object" && obj !== null) {
     for (const [key, value] of Object.entries(obj)) {
       result += `${spaces}${key}: `;
-      if (typeof value === 'object' && value !== null) {
-        result += '\n' + jsonToYaml(value, indent + 1);
+      if (typeof value === "object" && value !== null) {
+        result += "\n" + jsonToYaml(value, indent + 1);
       } else {
-        result += yamlValue(value) + '\n';
+        result += yamlValue(value) + "\n";
       }
     }
   }
@@ -400,9 +436,9 @@ function jsonToYaml(obj: any, indent = 0): string {
 }
 
 function yamlValue(value: any): string {
-  if (typeof value === 'string') {
+  if (typeof value === "string") {
     // Simple string escaping for YAML
-    if (value.includes('\n') || value.includes('"') || value.includes("'")) {
+    if (value.includes("\n") || value.includes('"') || value.includes("'")) {
       return `"${value.replace(/"/g, '\\"')}"`;
     }
     return value;
@@ -415,10 +451,10 @@ function evaluationToMarkdown(data: any): string {
   const evaluation = data.evaluation;
   const agent = data.agent;
   const job = data.job;
-  if (!evaluation) return '';
+  if (!evaluation) return "";
 
   let md = `# Evaluation Report\n\n`;
-  
+
   if (data.document?.id) {
     md += `**Document ID:** ${data.document.id}\n`;
   }
@@ -437,7 +473,7 @@ function evaluationToMarkdown(data: any): string {
   if (evaluation.createdAt) {
     md += `**Created:** ${new Date(evaluation.createdAt).toLocaleString()}\n`;
   }
-  
+
   // Job details section
   if (job) {
     md += `\n## Job Details\n\n`;
@@ -448,7 +484,10 @@ function evaluationToMarkdown(data: any): string {
       md += `**Status:** ${job.status}\n`;
     }
     if (job.priceInDollars !== null && job.priceInDollars !== undefined) {
-      const price = typeof job.priceInDollars === 'string' ? parseFloat(job.priceInDollars) : job.priceInDollars;
+      const price =
+        typeof job.priceInDollars === "string"
+          ? parseFloat(job.priceInDollars)
+          : job.priceInDollars;
       md += `**Cost:** $${price.toFixed(4)}\n`;
     }
     if (job.durationInSeconds !== null && job.durationInSeconds !== undefined) {
@@ -479,7 +518,7 @@ function evaluationToMarkdown(data: any): string {
       md += `**Logs:**\n\`\`\`\n${job.logs}\n\`\`\`\n`;
     }
   }
-  
+
   md += `\n---\n\n`;
 
   if (evaluation.summary) {
@@ -504,14 +543,14 @@ function evaluationToMarkdown(data: any): string {
       // Use header if available, otherwise use generic title
       const header = comment.header || `Comment ${index + 1}`;
       md += `### ${header}\n\n`;
-      
+
       // Add level and source badges
       if (comment.level || comment.source) {
         if (comment.level) md += `[${comment.level.toUpperCase()}] `;
         if (comment.source) md += `[${comment.source}] `;
         md += `\n\n`;
       }
-      
+
       if (comment.description) {
         md += `${comment.description}\n\n`;
       }

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { RadioGroup, RadioGroupItem }

--- a/apps/web/src/constants/ui-labels.ts
+++ b/apps/web/src/constants/ui-labels.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared UI labels and icons to maintain consistency across the app
+ */
+
+export const UI_LABELS = {
+  EVAL_EDITOR: {
+    label: "Eval Editor",
+    description: "Edit and manage evaluations for this document",
+  },
+} as const;

--- a/internal-packages/db/prisma/schema.prisma
+++ b/internal-packages/db/prisma/schema.prisma
@@ -93,8 +93,8 @@ model DocumentVersion {
   createdAt             DateTime                 @default(now())
   updatedAt             DateTime                 @updatedAt
   importUrl             String?
-  searchableText        String?                  @default(dbgenerated("lower(((((((((COALESCE(title, ''::text) || ' '::text) || COALESCE(immutable_array_to_string(authors, ' '::text), ''::text)) || ' '::text) || COALESCE(immutable_array_to_string(platforms, ' '::text), ''::text)) || ' '::text) || COALESCE(immutable_array_to_string(urls, ' '::text), ''::text)) || ' '::text) || COALESCE(\"importUrl\", ''::text)))"))
-  content_search_vector Unsupported("tsvector")? @default(dbgenerated("to_tsvector('english'::regconfig, COALESCE(\"left\"(content, 10000), ''::text))"))
+  searchableText        String?
+  content_search_vector Unsupported("tsvector")?
   contentSearchVector   Unsupported("tsvector")?
   markdownPrepend       String?
   document              Document                 @relation(fields: [documentId], references: [id], onDelete: Cascade)

--- a/internal-packages/db/prisma/schema.prisma
+++ b/internal-packages/db/prisma/schema.prisma
@@ -93,8 +93,8 @@ model DocumentVersion {
   createdAt             DateTime                 @default(now())
   updatedAt             DateTime                 @updatedAt
   importUrl             String?
-  searchableText        String?
-  content_search_vector Unsupported("tsvector")?
+  searchableText        String?                  @default(dbgenerated("lower(((((((((COALESCE(title, ''::text) || ' '::text) || COALESCE(immutable_array_to_string(authors, ' '::text), ''::text)) || ' '::text) || COALESCE(immutable_array_to_string(platforms, ' '::text), ''::text)) || ' '::text) || COALESCE(immutable_array_to_string(urls, ' '::text), ''::text)) || ' '::text) || COALESCE(\"importUrl\", ''::text)))"))
+  content_search_vector Unsupported("tsvector")? @default(dbgenerated("to_tsvector('english'::regconfig, COALESCE(\"left\"(content, 10000), ''::text))"))
   contentSearchVector   Unsupported("tsvector")?
   markdownPrepend       String?
   document              Document                 @relation(fields: [documentId], references: [id], onDelete: Cascade)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1974,6 +1977,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7354,6 +7370,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.0)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.7(@types/react@19.1.0)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.0)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.0)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.0)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.0)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.0)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:


### PR DESCRIPTION
### **User description**
## Summary
This PR includes several UI improvements to enhance the document management experience and privacy controls across the application.

## Changes

### Document Actions Improvements
- Moved "Refresh from Source" and "Delete" actions into a dropdown menu for cleaner UI
- Relocated all action buttons to Document Preview header for better visibility
- Made buttons smaller (size="sm") for improved visual hierarchy

### Evaluation Management Enhancements
- Updated EvaluationActions to use shadcn Button components for consistency
- Changed button colors: Details button to black, links to blue (from purple)
- Made agent names clickable links to agent pages
- Removed N/A badge when no grade exists
- Renamed "Details" button to "View Results" for clarity

### Privacy Controls Redesign
- Replaced checkbox with radio button groups for privacy selection
- Added visual icons (globe for public, lock for private) for better UX
- Implemented privacy toggle functionality with descriptive button text ("Make Public"/"Make Private")
- Applied consistent radio button UI to both edit page and create form

### Create Document Form Improvements
- Moved supported platforms section directly under URL input field for better visibility
- Improved text formatting and layout for supported platforms list

## Test Plan
- [x] Tested document actions dropdown functionality
- [x] Verified privacy toggle works correctly on document pages
- [x] Confirmed radio buttons function properly on edit and create forms
- [x] Checked that all agent name links navigate correctly
- [x] Validated button styling and color changes
- [x] Ensured TypeScript compilation passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Redesigned privacy controls with radio buttons and visual icons

- Moved document actions into dropdown menu for cleaner UI

- Updated evaluation management with shadcn components and improved styling

- Added privacy toggle functionality for document owners


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Privacy Controls"] --> B["Radio Button Groups"]
  B --> C["Visual Icons (Globe/Lock)"]
  D["Document Actions"] --> E["Dropdown Menu"]
  E --> F["Edit/Refresh/Delete"]
  G["Evaluation Management"] --> H["Shadcn Button Components"]
  H --> I["Improved Color Scheme"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td><strong>actions.ts</strong><dd><code>Add privacy toggle server action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-fb103a03e53e165bc42f8a318d72008e9f65c881c37b27240107451a25fb1fcb">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluationManagement.tsx</strong><dd><code>Update evaluation management with shadcn components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-5ab3f48f5980d88c80882e4a409ac45aa089ebb4851f43b94d5270c486212231">+61/-43</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ManagementEvaluationCard.tsx</strong><dd><code>Improve evaluation card styling and remove N/A badges</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-d287cc9af40f7d3744b66611a25e7e12ac4cc743fde814e4d156dc4e8f71aafc">+15/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>PrivacySection.tsx</strong><dd><code>Create privacy toggle component for document pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-23b6181850e7891e14ec5ce989073bd89592164a9b57b32dad0c8741dc63b513">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Replace privacy checkbox with radio button group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-312cc263343fd40497aba16bc582f45da02a76db4d29e1847252ef408aa6c1ba">+34/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Redesign document overview page layout and actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-8ab1731aecaa31630f69bc267cc28c32dc19aff7299ed9d152f2c73779cd5ed4">+43/-85</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Update import page with simplified platform text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-5c1cab45fa34d7038b21a99e4cbd9fcffb0489ae34bb2f4f46f4bc6ce6e0a234">+33/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CreateDocumentForm.tsx</strong><dd><code>Replace privacy checkbox with radio button interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-53392fc33a88294fb7af9abee839c298174ced575caea4b3843b60413db9061f">+147/-105</a></td>

</tr>

<tr>
  <td><strong>DocumentActions.tsx</strong><dd><code>Move actions into dropdown menu with shadcn components</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-5bd7d8051456ad9baf8626d9748c05169ee34b677dccb47005b33699edb857c0">+58/-83</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentEvaluationSidebar.tsx</strong><dd><code>Update sidebar with eval editor branding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-804c7ed28a024110f40d7ae875479a88e04b8cc01bc25814f91eb263917bcbf6">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommentToolbar.tsx</strong><dd><code>Create new comment toolbar component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-e48c4d0d5816c8a9303a23b496caf6465011f39f2e13c59dab6e54786f001589">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentContent.tsx</strong><dd><code>Remove full width toggle from document content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-b08b6e1d42cc2b26ba5e14d63f9a96184fee2af474af178909a3db1a20cd005c">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentMetadata.tsx</strong><dd><code>Simplify metadata component with shadcn buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-cfae907ce7f84134f7c03e4fa7d56f0c2b3e83a532bb861b1ea85887b1ba6ddc">+26/-198</a></td>

</tr>

<tr>
  <td><strong>EvaluationView.tsx</strong><dd><code>Integrate comment toolbar into evaluation view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-ffa3ef7d48625924cf4ae658528865744c38572b9265af1abb9ce618838751f3">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluationActions.tsx</strong><dd><code>Update evaluation actions with shadcn button components</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-7f39e7a3cbf32aa7db2b9d7db118c72de85e62e8fd90f2c5f58302995587bc78">+24/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>EvaluationStats.tsx</strong><dd><code>Change link colors from purple to blue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-facf924e99e5b49096143b9eb628eba64b89dbd6cc6b97248c2692169f3684f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>radio-group.tsx</strong><dd><code>Add shadcn radio group component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-c1721dd5e88e5f0292aa1a4d695248356879e3193dfcabafdead9ea294182a02">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ui-labels.ts</strong><dd><code>Create shared UI labels constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-35897dba6dcd59024100b026a8a77fc81c14b362ae9bb73815ca7aaa521e8fca">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.prisma</strong><dd><code>Remove database generated defaults from schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-2f79b7f4d8cb61c0e2832d98f50a5d46f3b6c019227e0232d72bfae412dc9863">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add radix radio group dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Update lockfile with radio group dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/243/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added Privacy controls: new sidebar section to view/toggle document privacy (owners only).
  * Introduced Comment Toolbar with full-width toggle and export (download or copy) in MD/YAML/JSON.
  * Document actions consolidated into Edit + menu (Refresh from Source, Delete) with evaluation-aware warning.
  * Reader View button on Document Preview.

* UI/UX
  * Privacy selection in forms changed to Public/Private radio options.
  * Refreshed icons, labels, and layout across document and evaluation views; clearer “Eval Editor” labeling.
  * Improved evaluation cards and management styling; agents sorted by badge status; Stale and grade display refinements.

* Bug Fixes
  * Fixed agent selection toggle on Import Document page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->