### PR TITLE
feat: add Submitter Notes field for document metadata

### DIFF
--- a/apps/web/src/app/docs/[docId]/edit/actions.ts
+++ b/apps/web/src/app/docs/[docId]/edit/actions.ts
@@ -17,6 +17,7 @@ type DocumentUpdateData = {
   intendedAgents?: string;
   importUrl?: string;
   isPrivate?: boolean;
+  submitterNotes?: string;
 };
 
 export async function updateDocument(
@@ -37,6 +38,7 @@ export async function updateDocument(
         intendedAgents: formData.get("intendedAgents") as string,
         importUrl: formData.get("importUrl") as string,
         isPrivate: formData.get("isPrivate") === "true",
+        submitterNotes: formData.get("submitterNotes") as string,
       };
     } else {
       // Handle direct object submission

--- a/apps/web/src/app/docs/[docId]/edit/page.tsx
+++ b/apps/web/src/app/docs/[docId]/edit/page.tsx
@@ -97,6 +97,7 @@ export default function EditDocumentPage({ params }: Props) {
       platforms: "",
       importUrl: "",
       isPrivate: false,
+      submitterNotes: "",
     },
   });
 
@@ -131,6 +132,7 @@ export default function EditDocumentPage({ params }: Props) {
               : "",
           importUrl: document.importUrl || "",
           isPrivate: document.isPrivate ?? false,
+          submitterNotes: document.submitterNotes || "",
         });
         
         // Update the local state for privacy
@@ -315,6 +317,24 @@ export default function EditDocumentPage({ params }: Props) {
                   className={`form-input w-full ${errors.content ? "border-red-500" : ""}`}
                   placeholder="Document content in Markdown format"
                 />
+              </FormField>
+
+              <FormField
+                name="submitterNotes"
+                label="Submitter Notes (Optional)"
+                error={errors.submitterNotes}
+              >
+                <textarea
+                  {...methods.register("submitterNotes")}
+                  id="submitterNotes"
+                  rows={4}
+                  className={`form-input w-full ${errors.submitterNotes ? "border-red-500" : ""}`}
+                  placeholder="Add any context or notes for readers. This will be displayed to readers but NOT included in AI evaluations."
+                />
+                <p className="mt-2 text-sm text-gray-600">
+                  These notes provide context for human readers but are not included in AI evaluations.
+                  Changing only submitter notes will NOT trigger re-evaluation of existing AI reviews.
+                </p>
               </FormField>
 
               <FormField

--- a/apps/web/src/app/docs/[docId]/page.tsx
+++ b/apps/web/src/app/docs/[docId]/page.tsx
@@ -158,6 +158,20 @@ export default async function DocumentPage({
             <div className="grid grid-cols-1 gap-8 lg:auto-rows-fr lg:grid-cols-3">
               {/* Main Content */}
               <div className="flex flex-col lg:col-span-2">
+                {/* Submitter Notes Card - only show if notes exist */}
+                {document.submitterNotes && (
+                  <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-6 shadow-sm">
+                    <h3 className="mb-3 text-sm font-semibold text-blue-900">
+                      Submitter's Notes
+                    </h3>
+                    <div className="prose prose-sm prose-blue max-w-none">
+                      <p className="text-blue-800 whitespace-pre-wrap">
+                        {document.submitterNotes}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
                 {/* Document Preview Card */}
                 <div className="flex flex-1 flex-col rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
                   <div className="mb-6 flex items-center justify-between">

--- a/apps/web/src/app/docs/new/CreateDocumentForm.tsx
+++ b/apps/web/src/app/docs/new/CreateDocumentForm.tsx
@@ -587,6 +587,23 @@ export default function CreateDocumentForm() {
                   </FormField>
                 ))}
 
+                <FormField
+                  name="submitterNotes"
+                  label="Submitter Notes (Optional)"
+                  error={errors.submitterNotes}
+                >
+                  <textarea
+                    {...methods.register("submitterNotes")}
+                    id="submitterNotes"
+                    rows={4}
+                    className={`mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${errors.submitterNotes ? "border-red-500" : ""}`}
+                    placeholder="Add any context or notes for readers. This will be displayed to readers but NOT included in AI evaluations."
+                  />
+                  <p className="mt-2 text-sm text-gray-600">
+                    These notes provide context for human readers but are not included in AI evaluations.
+                  </p>
+                </FormField>
+
                 <PrivacyToggle
                   isPrivate={methods.watch("isPrivate") || false}
                   onChange={(value) => methods.setValue("isPrivate", value)}

--- a/apps/web/src/app/docs/new/actions.ts
+++ b/apps/web/src/app/docs/new/actions.ts
@@ -29,7 +29,8 @@ export async function createDocument(data: DocumentInput, agentIds: string[] = [
         url: data.urls,
         platforms: data.platforms ? [data.platforms] : [],
         importUrl: data.importUrl,
-        isPrivate: data.isPrivate ?? true
+        isPrivate: data.isPrivate ?? true,
+        submitterNotes: data.submitterNotes
       },
       agentIds
     );

--- a/apps/web/src/app/docs/new/schema.ts
+++ b/apps/web/src/app/docs/new/schema.ts
@@ -20,6 +20,7 @@ export const documentSchema = z.object({
   platforms: z.string().optional(),
   importUrl: z.string().optional(),
   isPrivate: z.boolean().optional().default(false),
+  submitterNotes: z.string().optional(),
 });
 
 export type DocumentInput = z.infer<typeof documentSchema>;

--- a/apps/web/src/components/DocumentWithEvaluations/components/DocumentContent.tsx
+++ b/apps/web/src/components/DocumentWithEvaluations/components/DocumentContent.tsx
@@ -49,6 +49,18 @@ export function DocumentContent({
         showDetailedAnalysisLink={true}
       />
 
+      {/* Submitter Notes - only show if notes exist */}
+      {document.submitterNotes && (
+        <div className="mx-4 mt-4 rounded-lg border border-blue-200 bg-blue-50 p-4">
+          <h3 className="mb-2 text-sm font-semibold text-blue-900">
+            Submitter's Notes
+          </h3>
+          <p className="text-sm text-blue-800 whitespace-pre-wrap">
+            {document.submitterNotes}
+          </p>
+        </div>
+      )}
+
       <article
         className={`prose prose-lg prose-slate ${
           isFullWidth

--- a/internal-packages/ai/src/types/documents.ts
+++ b/internal-packages/ai/src/types/documents.ts
@@ -74,6 +74,7 @@ export interface Document {
   platforms?: string[];
   reviews: Evaluation[];
   intendedAgents: string[];
+  submitterNotes?: string;
 }
 
 export interface DocumentsCollection {

--- a/internal-packages/db/prisma/migrations/20250907131752_add_submitter_notes/migration.sql
+++ b/internal-packages/db/prisma/migrations/20250907131752_add_submitter_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DocumentVersion" ADD COLUMN "submitterNotes" TEXT;

--- a/internal-packages/db/prisma/schema.prisma
+++ b/internal-packages/db/prisma/schema.prisma
@@ -97,6 +97,7 @@ model DocumentVersion {
   content_search_vector Unsupported("tsvector")? @default(dbgenerated("to_tsvector('english'::regconfig, COALESCE(\"left\"(content, 10000), ''::text))"))
   contentSearchVector   Unsupported("tsvector")?
   markdownPrepend       String?
+  submitterNotes        String?
   document              Document                 @relation(fields: [documentId], references: [id], onDelete: Cascade)
   evaluationVersions    EvaluationVersion[]
 

--- a/internal-packages/db/src/repositories/DocumentRepository.ts
+++ b/internal-packages/db/src/repositories/DocumentRepository.ts
@@ -61,6 +61,7 @@ export interface CreateDocumentData {
   ephemeralBatchId?: string;
   markdownPrepend?: string;
   isPrivate?: boolean;
+  submitterNotes?: string;
 }
 
 export interface UpdateDocumentData {
@@ -327,6 +328,7 @@ export class DocumentRepository implements DocumentRepositoryInterface {
             platforms: data.platforms || [],
             importUrl: data.importUrl,
             markdownPrepend: data.markdownPrepend,
+            submitterNotes: data.submitterNotes,
             version: 1
           }
         }

--- a/internal-packages/domain/src/services/DocumentService.ts
+++ b/internal-packages/domain/src/services/DocumentService.ts
@@ -41,6 +41,7 @@ export interface CreateDocumentRequest {
   importUrl?: string;
   ephemeralBatchId?: string;
   isPrivate?: boolean;
+  submitterNotes?: string;
 }
 
 export interface UpdateDocumentRequest {
@@ -97,7 +98,8 @@ export class DocumentService {
         importUrl: data.importUrl,
         ephemeralBatchId: data.ephemeralBatchId,
         markdownPrepend,
-        isPrivate: data.isPrivate || false
+        isPrivate: data.isPrivate || false,
+        submitterNotes: data.submitterNotes
       };
 
       const repoDocument = await this.docRepo.create(createData);


### PR DESCRIPTION
### **User description**
## Summary
Adds a new "Submitter Notes" field that provides context for human readers but is NOT included in AI evaluations. This allows document submitters to add helpful context and metadata without affecting the evaluation results.

## Key Changes
- ✨ Added `submitterNotes` field to `DocumentVersion` table with migration
- 🧠 Implemented smart staleness logic: changing only submitter notes does NOT trigger re-evaluations
- 🎨 Added UI components for entering and displaying submitter notes
- 📝 Integrated into both document creation and editing workflows

## Implementation Details

### Database
- Added nullable `submitterNotes` text field to `DocumentVersion` schema
- Created proper migration file for database update

### Smart Staleness Logic
- Modified `Document.update()` to detect when ONLY submitterNotes changed
- If only notes changed, creates new version but doesn't mark evaluations as stale
- Prevents unnecessary API costs from re-running evaluations for metadata changes

### UI Components
- **Create Document Form**: Added optional textarea below content field
- **Edit Document Form**: Added field with explanation about staleness behavior  
- **Document Overview Page**: Displays notes in blue info box above preview
- **Reader View**: Shows notes prominently below metadata, above content

### Backend Updates
- Updated all relevant TypeScript interfaces and types
- Modified DocumentService and DocumentRepository to handle submitterNotes
- Updated API routes and server actions

## Benefits
- 📖 Provides valuable context for human readers
- 🔒 Maintains evaluation integrity (LLMs don't see the notes)
- 💰 Reduces unnecessary re-evaluations and API costs
- 🚀 Improves document submission workflow

## Testing
- ✅ All existing tests pass
- ✅ TypeScript compilation successful
- ✅ Linting passes (only existing warnings)
- ✅ Verified staleness logic works correctly

## Screenshots
The submitter notes appear in a distinctive blue box to differentiate them from document content:
- On document overview page: Above the document preview
- On reader view: Below document metadata, above content

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `submitterNotes` field to document metadata

- Implement smart staleness logic for evaluation efficiency

- Display notes prominently in blue info boxes

- Integrate into create and edit document forms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Document Form"] --> B["submitterNotes Field"]
  B --> C["Database Storage"]
  C --> D["Smart Staleness Check"]
  D --> E["Skip Re-evaluation"]
  D --> F["Display in UI"]
  F --> G["Blue Info Box"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>schema.prisma</strong><dd><code>Add submitterNotes column to DocumentVersion table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-2f79b7f4d8cb61c0e2832d98f50a5d46f3b6c019227e0232d72bfae412dc9863">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migration.sql</strong><dd><code>Database migration for submitterNotes field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-17114c58ebdff9994986f5c5d94212af1f7e23bf5a277ecea38d4ba72bef2bb7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Document.ts</strong><dd><code>Implement smart staleness logic for submitter notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-9300505e835d1b71f472c613342e3e22f6306270afa28ef690029b138c392a50">+40/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>schema.ts</strong><dd><code>Add submitterNotes to document validation schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-eb69d6076531c0bcc3648694649a3b3ac8c38acf1b52b11dceaad014ebe2d188">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentService.ts</strong><dd><code>Update DocumentService to handle submitterNotes field</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-130bca8c402ced4f9bc2490c5d7578a9a95ddbe17a3e6b33dba5c71d4d6f3d0e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentRepository.ts</strong><dd><code>Add submitterNotes support in document repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-73b6eae4947fb3642e66386b78763aedfd5fbe013ec08a6a69093a27f318c839">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>documents.ts</strong><dd><code>Add submitterNotes to Document interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-7c84921920edbe4f10ad7cf06f50a74d98a21f64ede96ef0ffed87eab7b11516">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CreateDocumentForm.tsx</strong><dd><code>Add submitter notes textarea to create form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-53392fc33a88294fb7af9abee839c298174ced575caea4b3843b60413db9061f">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Add submitter notes field to edit form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-312cc263343fd40497aba16bc582f45da02a76db4d29e1847252ef408aa6c1ba">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>actions.ts</strong><dd><code>Handle submitterNotes in document update action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-f92900651b82ed99cd1699422b201a6de889b82fede2c3145d4056e49b20b21a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>actions.ts</strong><dd><code>Include submitterNotes in document creation action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-bfd1ed629a8b887d502ba544b8ee5e1d2490ddb835ef2e2e9fda585f8c9dd2d0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Display submitter notes in blue info box</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-8ab1731aecaa31630f69bc267cc28c32dc19aff7299ed9d152f2c73779cd5ed4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DocumentContent.tsx</strong><dd><code>Show submitter notes in document reader view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/244/files#diff-b08b6e1d42cc2b26ba5e14d63f9a96184fee2af474af178909a3db1a20cd005c">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Submitter Notes” field to create and edit document forms for adding context to readers.
  * Displays a “Submitter’s Notes” card on document pages when notes are provided; formatting is preserved.
  * Notes are visible to readers only and are not used in AI evaluations.
  * Updating only the notes will not trigger re-evaluation.
  * Available across manual document creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->