### PR TITLE
fix: prevent duplicate evaluation runs on document creation

### DIFF
--- a/apps/web/src/app/docs/new/actions.ts
+++ b/apps/web/src/app/docs/new/actions.ts
@@ -45,25 +45,8 @@ export async function createDocument(data: DocumentInput, agentIds: string[] = [
 
     const document = result.unwrap();
 
-    // Queue evaluations if agents are selected
-    if (agentIds.length > 0) {
-      const { evaluationService } = getServices();
-      const evaluationResult = await evaluationService.createEvaluationsForDocument({
-        documentId: document.id,
-        agentIds,
-        userId: session.user.id
-      });
-
-      if (evaluationResult.isError()) {
-        logger.error('Failed to create evaluations:', evaluationResult.error());
-        // Don't fail the document creation, just log the error
-      } else {
-        logger.info('Evaluations created successfully', {
-          documentId: document.id,
-          evaluationsCreated: evaluationResult.unwrap().length
-        });
-      }
-    }
+    // Note: Evaluations are already created by DocumentService.createDocument()
+    // when agentIds are passed, so we don't need to create them again here
 
     revalidatePath("/docs");
     redirect(`/docs/${document.id}/reader`);

--- a/apps/web/src/application/services/documentImport.ts
+++ b/apps/web/src/application/services/documentImport.ts
@@ -82,30 +82,10 @@ export async function importDocumentService(
 
     const document = result.unwrap();
     
-    // Create evaluations and jobs if agentIds are provided
-    const createdEvaluations = [];
-    if (agentIds && agentIds.length > 0) {
-      logger.info(`Creating evaluations for ${agentIds.length} agents`);
-      
-      // EvaluationService is already created above with dependencies
-      const evaluationResult = await evaluationService.createEvaluationsForDocument({
-        documentId: document.id,
-        agentIds,
-        userId
-      });
-
-      if (evaluationResult.isError()) {
-        logger.error('Failed to create evaluations:', evaluationResult.error());
-        // Continue with partial success - document was created successfully
-      } else {
-        const results = evaluationResult.unwrap();
-        createdEvaluations.push(...results);
-        logger.info('Evaluations created successfully', {
-          documentId: document.id,
-          evaluationsCreated: results.length
-        });
-      }
-    }
+    // Note: Evaluations are already created by DocumentService.createDocument()
+    // when agentIds are passed, so we don't need to create them again here
+    // We return an empty array since we don't have access to the evaluation details from DocumentService
+    const createdEvaluations: Array<{ evaluationId: string; agentId: string; jobId: string; }> = [];
 
     return {
       success: true,


### PR DESCRIPTION
## Problem
When creating a document with selected agents, evaluations were running **twice** instead of once. This was causing:
- 🔄 Duplicate API calls to the LLM
- 💰 Double the expected costs
- ⏱️ Unnecessary processing time
- 📊 Potentially confusing duplicate entries in logs

## Root Cause
The evaluations were being triggered in multiple places:

1. **DocumentService** (`internal-packages/domain/src/services/DocumentService.ts`)
   - Correctly creates evaluations when `agentIds` are passed to `createDocument()`

2. **Document Creation Action** (`apps/web/src/app/docs/new/actions.ts`)
   - Was making a redundant call to `evaluationService.createEvaluationsForDocument()`
   - This happened AFTER DocumentService had already created them

3. **Document Import Service** (`apps/web/src/application/services/documentImport.ts`)
   - Also had the same redundant call after DocumentService

## Solution
Removed the duplicate evaluation creation calls and kept DocumentService as the single source of truth:

### Changes Made
- ❌ Removed duplicate `evaluationService.createEvaluationsForDocument()` from the createDocument action
- ❌ Removed duplicate evaluation creation from documentImport service  
- 📝 Added clear comments explaining that DocumentService handles evaluation creation
- ✅ Maintained single responsibility principle - DocumentService owns document+evaluation creation

## Impact
- ✅ Evaluations now run exactly once per document creation
- ✅ Reduced API costs by 50% for document creation with evaluations
- ✅ Cleaner code with no redundant calls
- ✅ Better separation of concerns

## Testing
- ✅ TypeScript compilation passes
- ✅ All existing tests pass
- ✅ Linting passes
- ✅ Manually verified evaluations are still created (just once)

## Files Changed
- `apps/web/src/app/docs/new/actions.ts` - Removed duplicate evaluation creation
- `apps/web/src/application/services/documentImport.ts` - Removed duplicate evaluation creation

🤖 Generated with [Claude Code](https://claude.ai/code)