### PR TITLE
Add dynamic page titles showing document title and author

### DIFF
--- a/apps/web/src/app/docs/[docId]/page.tsx
+++ b/apps/web/src/app/docs/[docId]/page.tsx
@@ -9,12 +9,12 @@ import type { Metadata } from "next";
 import { BreadcrumbHeader } from "@/components/BreadcrumbHeader";
 import { DocumentActions } from "@/components/DocumentActions";
 import { DocumentEvaluationSidebar } from "@/components/DocumentEvaluationSidebar";
-import { PrivacyBadge } from "@/components/PrivacyBadge";
 import SlateEditor from "@/components/SlateEditor";
 import { Button } from "@/components/ui/button";
 import { auth } from "@/infrastructure/auth/auth";
 import { prisma } from "@/infrastructure/database/prisma";
 import { DocumentModel } from "@/models/Document";
+import { generateDocumentMetadata } from "@/lib/document-metadata";
 
 import { EvaluationManagement } from "./components/EvaluationManagement";
 import { PrivacySection } from "./components/PrivacySection";
@@ -25,36 +25,7 @@ export async function generateMetadata({
   params: Promise<{ docId: string }>;
 }): Promise<Metadata> {
   const resolvedParams = await params;
-  const docId = resolvedParams.docId;
-
-  const document = await prisma.document.findUnique({
-    where: { id: docId },
-    select: {
-      versions: {
-        orderBy: { version: "desc" },
-        take: 1,
-        select: {
-          title: true,
-          authors: true,
-        },
-      },
-    },
-  });
-
-  if (!document || !document.versions[0]) {
-    return {
-      title: "Document Not Found - RoastMyPost",
-    };
-  }
-
-  const version = document.versions[0];
-  const title = version.title || "Untitled Document";
-  const authorPrefix = version.authors?.length > 0 ? `by ${version.authors.join(", ")} - ` : "";
-
-  return {
-    title: `${title} ${authorPrefix}RoastMyPost`,
-    description: `View and manage evaluations for "${title}"`,
-  };
+  return generateDocumentMetadata(resolvedParams.docId);
 }
 
 async function getAvailableAgents(docId: string) {

--- a/apps/web/src/app/docs/[docId]/reader/page.tsx
+++ b/apps/web/src/app/docs/[docId]/reader/page.tsx
@@ -4,8 +4,8 @@ import type { Metadata } from "next";
 
 import { DocumentWithEvaluations } from "@/components/DocumentWithEvaluations";
 import { auth } from "@/infrastructure/auth/auth";
-import { prisma } from "@/infrastructure/database/prisma";
 import { DocumentModel } from "@/models/Document";
+import { generateDocumentMetadata } from "@/lib/document-metadata";
 
 export async function generateMetadata({
   params,
@@ -13,36 +13,7 @@ export async function generateMetadata({
   params: Promise<{ docId: string }>;
 }): Promise<Metadata> {
   const resolvedParams = await params;
-  const docId = resolvedParams.docId;
-
-  const document = await prisma.document.findUnique({
-    where: { id: docId },
-    select: {
-      versions: {
-        orderBy: { version: "desc" },
-        take: 1,
-        select: {
-          title: true,
-          authors: true,
-        },
-      },
-    },
-  });
-
-  if (!document || !document.versions[0]) {
-    return {
-      title: "Reader - RoastMyPost",
-    };
-  }
-
-  const version = document.versions[0];
-  const title = version.title || "Untitled Document";
-  const authorPrefix = version.authors?.length > 0 ? `by ${version.authors.join(", ")} - ` : "";
-
-  return {
-    title: `${title} ${authorPrefix}Reader - RoastMyPost`,
-    description: `Read "${title}" with AI evaluations`,
-  };
+  return generateDocumentMetadata(resolvedParams.docId, { suffix: "Reader" });
 }
 
 export default async function DocumentPage({

--- a/apps/web/src/lib/document-metadata.ts
+++ b/apps/web/src/lib/document-metadata.ts
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import { auth } from "@/infrastructure/auth/auth";
+import { PrivacyService } from "@/infrastructure/auth/privacy-service";
+import { prisma } from "@/infrastructure/database/prisma";
+
+interface DocumentMetadataOptions {
+  suffix?: string;
+  fallbackTitle?: string;
+}
+
+/**
+ * Generate metadata for document pages with privacy checks.
+ * This ensures private document information is never leaked through page metadata.
+ * 
+ * @param docId - The document ID to generate metadata for
+ * @param options - Optional configuration for metadata generation
+ * @returns Metadata object with appropriate title and description
+ */
+export async function generateDocumentMetadata(
+  docId: string,
+  options?: DocumentMetadataOptions
+): Promise<Metadata> {
+  // Check if user has permission to view this document
+  const session = await auth();
+  const canView = await PrivacyService.canViewDocument(docId, session?.user?.id);
+  
+  // Return generic metadata if access is denied to prevent information leakage
+  if (!canView) {
+    return {
+      title: options?.fallbackTitle || "Document Not Found - RoastMyPost",
+      // Prevent indexing of pages that user cannot access
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+  
+  // Query for document metadata
+  const document = await prisma.document.findUnique({
+    where: { id: docId },
+    select: {
+      isPrivate: true,
+      versions: {
+        orderBy: { version: "desc" },
+        take: 1,
+        select: {
+          title: true,
+          authors: true,
+        },
+      },
+    },
+  });
+
+  // Handle case where document doesn't exist or has no versions
+  if (!document || !document.versions[0]) {
+    return {
+      title: options?.fallbackTitle || "Document Not Found - RoastMyPost",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  // Format title components
+  const version = document.versions[0];
+  const title = version.title || "Untitled Document";
+  const authorPart = version.authors && version.authors.length > 0
+    ? ` by ${version.authors.join(", ")}`
+    : "";
+  const suffixPart = options?.suffix ? ` - ${options.suffix}` : "";
+
+  // Generate description based on context
+  let description: string;
+  if (options?.suffix === "Reader") {
+    description = `Read "${title}" with AI evaluations`;
+  } else {
+    description = `View and manage evaluations for "${title}"`;
+  }
+
+  return {
+    title: `${title}${authorPart}${suffixPart} - RoastMyPost`,
+    description,
+    // Set robots meta based on document privacy
+    // Private documents should not be indexed by search engines
+    robots: {
+      index: !document.isPrivate,
+      follow: !document.isPrivate,
+      ...(document.isPrivate && {
+        noarchive: true,
+        nosnippet: true,
+        noimageindex: true,
+      }),
+    },
+  };
+}


### PR DESCRIPTION
### **User description**
- Add generateMetadata to document overview page
- Add generateMetadata to document reader page
- Tab titles now show '[Document Title] by [Author] - RoastMyPost' instead of URL

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add dynamic page titles showing document title and author

- Implement generateMetadata functions for document pages

- Replace generic URLs with descriptive tab titles

- Include fallback handling for missing documents


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Document Pages"] --> B["generateMetadata Function"]
  B --> C["Fetch Document Data"]
  C --> D["Extract Title & Authors"]
  D --> E["Generate Dynamic Title"]
  E --> F["Browser Tab Title"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add dynamic metadata to document overview page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/docs/[docId]/page.tsx

<ul><li>Add generateMetadata function to fetch document title and authors<br> <li> Import Metadata type from Next.js<br> <li> Generate dynamic page titles with format '[Title] by [Author] - <br>RoastMyPost'<br> <li> Include fallback for missing documents</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/249/files#diff-8ab1731aecaa31630f69bc267cc28c32dc19aff7299ed9d152f2c73779cd5ed4">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add dynamic metadata to document reader page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/docs/[docId]/reader/page.tsx

<ul><li>Add generateMetadata function for reader page<br> <li> Import Metadata type and prisma client<br> <li> Generate titles with format '[Title] by [Author] - Reader - <br>RoastMyPost'<br> <li> Include description metadata for SEO</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/249/files#diff-c9de8da43329ece100eb5dffbdaee3655a68a614fa4d360997b24a37ea7e58f1">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic, privacy-aware page metadata for document and reader pages: titles and descriptions reflect the latest document title, authors, and a "Reader" suffix where applicable.
  * Private or missing documents now yield safe fallback titles/descriptions and prevent indexing/sharing (robots directives) to avoid leaking private info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->