### PR TITLE
fix: Treat Claude API timeouts as non-retryable errors

### DIFF
--- a/internal-packages/jobs/src/errors/retryableErrors.ts
+++ b/internal-packages/jobs/src/errors/retryableErrors.ts
@@ -41,6 +41,9 @@ const NON_RETRYABLE_PATTERNS = [
 
   // This is the hard limit and we discard this result so we don't want to retry it
   'response was truncated at 8000 tokens',
+
+  // Claude API timeouts indicate systemic issues (document too large/complex) - won't resolve with retries
+  'claude api call timed out',
 ];
 
 /**


### PR DESCRIPTION
### **User description**
Claude API timeouts (180s) indicate systemic issues like documents being too large or complex. Retrying wastes resources and delays failure feedback to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Treat Claude API timeouts as non-retryable errors

- Prevents wasteful retry attempts on systemic issues

- Improves failure feedback speed to users


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Claude API timeout<br/>180s limit"] -->|Previously| B["Retried<br/>wastes resources"]
  A -->|Now| C["Non-retryable<br/>fast failure"]
  C --> D["User feedback<br/>improved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retryableErrors.ts</strong><dd><code>Add Claude timeout to non-retryable error patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/jobs/src/errors/retryableErrors.ts

<ul><li>Added 'claude api call timed out' to <code>NON_RETRYABLE_PATTERNS</code> array<br> <li> Added explanatory comment indicating timeouts signal systemic issues<br> <li> Prevents retry logic from attempting failed Claude API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/367/files#diff-825e2dfd991d30a59d6d4b7b9fd206712bfe39b15856b62acad43a20a4545c60">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

