### PR TITLE
fix: Use last 4 chars of hostname for worker ID differentiation

### DIFF
--- a/internal-packages/ai/src/shared/jobContext.ts
+++ b/internal-packages/ai/src/shared/jobContext.ts
@@ -20,11 +20,12 @@ interface JobContext {
 const contextStorage = new AsyncLocalStorage<JobContext>();
 
 /**
- * Generate worker ID: hostname(4) + pid(4), max 8 chars
- * Example: "host1234" or "node5678"
+ * Generate worker ID: hostname(last 4) + pid(4), max 8 chars
+ * Uses last 4 chars of hostname since prefixes are often identical across workers
+ * Example: "er-11234" or "xyz95678"
  */
 function generateWorkerId(): string {
-  const host = hostname().slice(0, 4);
+  const host = hostname().slice(-4);
   const pid = process.pid.toString().slice(-4).padStart(4, '0');
   return `${host}${pid}`.slice(0, 8);
 }


### PR DESCRIPTION
### **User description**
Hostnames often share common prefixes (e.g., "roast-worker-xxx"), making the first 4 chars identical across workers. Using the last 4 chars provides better differentiation in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Changed worker ID generation to use last 4 chars of hostname

- Improves worker differentiation in logs with common prefixes

- Updated documentation and examples to reflect new behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  hostname["hostname"] -- "slice last 4 chars" --> host["host"]
  pid["process.pid"] -- "slice last 4 chars" --> pidStr["pid string"]
  host -- "concatenate" --> workerId["workerId"]
  pidStr -- "concatenate" --> workerId
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jobContext.ts</strong><dd><code>Use last 4 chars of hostname for worker ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ai/src/shared/jobContext.ts

<ul><li>Changed <code>hostname().slice(0, 4)</code> to <code>hostname().slice(-4)</code> for better <br>worker differentiation<br> <li> Updated JSDoc comment to clarify using last 4 chars instead of first 4<br> <li> Updated example comments from "host1234" to "er-11234" to reflect new <br>behavior<br> <li> Maintains same max 8 char format (4 hostname + 4 pid chars)</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/368/files#diff-de5f146038500aa44ac07d679180359f914df904e0657f4e49e85317fa2aa7c7">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

