### PR TITLE
fix: Block AI crawlers and reduce worker polling frequency

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,57 @@
 User-agent: *
 Allow: /
+Crawl-delay: 10
+
+# Block AI training crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Omgili
+Disallow: /
 
 Sitemap: https://roastmypost.org/sitemap.xml

--- a/internal-packages/jobs/src/cli/process-pgboss-worker.ts
+++ b/internal-packages/jobs/src/cli/process-pgboss-worker.ts
@@ -33,8 +33,8 @@ import { updateJobCostsFromHelicone } from '../scheduled-tasks/helicone-poller';
 import { JobReconciliationService } from '../scheduled-tasks/job-reconciliation';
 
 // Schedule constants
-const HELICONE_POLLER_SCHEDULE = '*/30 * * * * *'; // Every 30 seconds
-const JOB_RECONCILIATION_SCHEDULE = '0 * * * * *'; // Every minute
+const HELICONE_POLLER_SCHEDULE = '*/5 * * * *'; // Every 5 minutes
+const JOB_RECONCILIATION_SCHEDULE = '*/10 * * * *'; // Every 10 minutes
 
 class PgBossWorker {
   private pgBossService: PgBossService;


### PR DESCRIPTION
### **User description**
## Summary

- Block major AI training crawlers via robots.txt (GPTBot, ClaudeBot, Google-Extended, CCBot, Meta, Perplexity, Amazon, Cohere, etc.)
- Add `Crawl-delay: 10` to slow down any crawlers that respect it
- Reduce Helicone cost poller from every 30s to every 5 minutes
- Reduce job reconciliation from every 1 minute to every 10 minutes

## Context

GPTBot was crawling the site aggressively, causing:
- ~700GB outgoing data transfer (vs 4GB previous cycle)
- 256 CPU hours (vs 2 previous cycle)
- 20M+ function invocations
- **~$100 in Vercel costs** (1000%+ increase)

The crawler was hitting `/docs/[docId]` and `/docs/[docId]/evals/[agentId]` pages repeatedly, with each response being ~500MB.

## Test plan

- [ ] Verify robots.txt is served correctly at https://roastmypost.org/robots.txt after deploy
- [ ] Monitor Vercel usage over next few days to confirm reduction
- [ ] Verify worker scheduled tasks still run (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Block major AI training crawlers via robots.txt (GPTBot, ClaudeBot, Google-Extended, CCBot, Meta, Perplexity, Amazon, Cohere, etc.)

- Add Crawl-delay directive to slow down crawler requests

- Reduce Helicone cost poller from 30 seconds to 5 minutes

- Reduce job reconciliation from 1 minute to 10 minutes

- Addresses aggressive GPTBot crawling causing 700GB+ data transfer and 1000%+ cost increase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["robots.txt Configuration"] -->|"Block AI crawlers"| B["Prevent GPTBot, ClaudeBot, etc."]
  A -->|"Add Crawl-delay: 10"| C["Slow down crawler requests"]
  D["Worker Polling Schedules"] -->|"Helicone: 30s → 5min"| E["Reduce API polling overhead"]
  D -->|"Job Reconciliation: 1min → 10min"| F["Lower worker task frequency"]
  B --> G["Reduce Vercel costs"]
  C --> G
  E --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>robots.txt</strong><dd><code>Block AI crawlers and add crawl delay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/public/robots.txt

<ul><li>Added Crawl-delay directive set to 10 seconds for all crawlers<br> <li> Blocked 15+ AI training crawlers including GPTBot, ClaudeBot, <br>Google-Extended, CCBot, Meta, Perplexity, Amazon, Cohere, and others<br> <li> Each blocked crawler has explicit Disallow: / rule<br> <li> Preserved existing Sitemap reference</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/370/files#diff-8340a151105afaf3e9ec7d666b67cce215e49d1ab517e6d980ff6841e36a5b4f">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>process-pgboss-worker.ts</strong><dd><code>Reduce worker polling frequency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/jobs/src/cli/process-pgboss-worker.ts

<ul><li>Changed HELICONE_POLLER_SCHEDULE from every 30 seconds to every 5 <br>minutes<br> <li> Changed JOB_RECONCILIATION_SCHEDULE from every 1 minute to every 10 <br>minutes<br> <li> Updated cron expression format and comments to reflect new intervals</ul>


</details>


  </td>
  <td><a href="https://github.com/quantified-uncertainty/roast-my-post/pull/370/files#diff-fa58c1e4963811258b9c0e4450aefeb3cc857ca0a65fd13507e0020a1e5bf0bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated robots.txt with crawl delay and expanded crawler block list for additional bot types
  * Adjusted polling schedules: Helicone poller now runs every 5 minutes (previously 30 seconds) and job reconciliation every 10 minutes (previously 1 minute)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->