### PR TITLE
feat: Batch completion tracking and email notifications

### DIFF
--- a/apps/web/src/app/api/evaluators/[agentId]/batches/route.ts
+++ b/apps/web/src/app/api/evaluators/[agentId]/batches/route.ts
@@ -81,7 +81,8 @@ export async function GET(
         ? gradesWithValues.reduce((sum, grade) => sum + grade, 0) / gradesWithValues.length 
         : null;
 
-      const progress = batch.targetCount ? (jobStats.completed / batch.targetCount) * 100 : 0;
+      const terminalCount = jobStats.completed + jobStats.failed;
+      const progress = jobStats.total > 0 ? (terminalCount / jobStats.total) * 100 : 0;
 
       return {
         id: batch.id,
@@ -96,7 +97,7 @@ export async function GET(
         totalCost,
         avgDuration: Math.round(avgDuration),
         avgGrade,
-        isComplete: batch.targetCount ? completedJobs.length === batch.targetCount : false,
+        isComplete: batch.completedAt !== null,
       };
     });
 

--- a/apps/web/src/app/api/evaluators/[agentId]/eval-batch/route.ts
+++ b/apps/web/src/app/api/evaluators/[agentId]/eval-batch/route.ts
@@ -8,6 +8,7 @@ interface CreateBatchRequest {
   name?: string;
   targetCount?: number;
   documentIds?: string[];
+  notifyOnComplete?: boolean;
 }
 
 export async function POST(
@@ -174,6 +175,7 @@ export async function POST(
         targetCount: targetCount,
         requestedDocumentIds: requestedDocumentIds,
         userId: userId,
+        notifyOnComplete: body.notifyOnComplete ?? false,
       },
     });
 

--- a/apps/web/src/app/api/monitor/jobs/[jobId]/cancel/route.ts
+++ b/apps/web/src/app/api/monitor/jobs/[jobId]/cancel/route.ts
@@ -5,6 +5,7 @@ import { JobStatus } from "@roast/db";
 import { authenticateRequest } from "@/infrastructure/auth/auth-helpers";
 import { commonErrors } from "@/infrastructure/http/api-response-helpers";
 import { isAdmin } from "@/infrastructure/auth/auth";
+import { getServices } from "@/application/services/ServiceFactory";
 
 export async function POST(
   request: NextRequest,
@@ -14,16 +15,16 @@ export async function POST(
   if (!userId) {
     return commonErrors.unauthorized();
   }
-  
+
   // Check if user is admin
   const adminCheck = await isAdmin();
   if (!adminCheck) {
     return commonErrors.forbidden();
   }
-  
+
   try {
     const { jobId } = await params;
-    
+
     // Parse request body for optional cancellation reason
     let cancellationReason: string | undefined;
     try {
@@ -32,20 +33,20 @@ export async function POST(
     } catch {
       // No body or invalid JSON is fine, reason is optional
     }
-    
+
     // Get the current job status
     const job = await prisma.job.findUnique({
       where: { id: jobId },
       select: { status: true }
     });
-    
+
     if (!job) {
       return NextResponse.json(
         { error: "Job not found" },
         { status: 404 }
       );
     }
-    
+
     // Only allow cancelling PENDING or RUNNING jobs
     if (job.status !== JobStatus.PENDING && job.status !== JobStatus.RUNNING) {
       return NextResponse.json(
@@ -53,16 +54,17 @@ export async function POST(
         { status: 400 }
       );
     }
-    
-    // Update the job with cancellation info
+
+    // Cancel via JobService (handles pg-boss + DB + batch completion check)
+    const { jobService } = getServices();
+    await jobService.cancelJob(jobId);
+
+    // Set admin-specific fields (cancelledById, custom reason)
     const updatedJob = await prisma.job.update({
       where: { id: jobId },
       data: {
-        status: JobStatus.CANCELLED,
-        cancelledAt: new Date(),
         cancelledById: userId,
-        cancellationReason,
-        completedAt: new Date(), // Set completion time for cancelled jobs
+        ...(cancellationReason && { cancellationReason }),
       },
       include: {
         cancelledBy: {
@@ -74,13 +76,13 @@ export async function POST(
         }
       }
     });
-    
+
     logger.info(`Job ${jobId} cancelled by admin ${userId}`, {
       jobId,
       adminId: userId,
       reason: cancellationReason || "No reason provided"
     });
-    
+
     return NextResponse.json({
       success: true,
       job: {
@@ -91,7 +93,7 @@ export async function POST(
         cancellationReason: updatedJob.cancellationReason,
       }
     });
-    
+
   } catch (error) {
     logger.error('Error cancelling job:', error);
     return commonErrors.serverError("Failed to cancel job");

--- a/apps/web/src/components/AgentDetail/tabs/TestTab.tsx
+++ b/apps/web/src/components/AgentDetail/tabs/TestTab.tsx
@@ -67,8 +67,11 @@ export function TestTab({
               const formData = new FormData(e.currentTarget);
               const name = formData.get("name") as string;
 
+              const notifyOnComplete = formData.get("notifyOnComplete") === "on";
+
               let requestBody: any = {
                 name: name || undefined,
+                notifyOnComplete,
               };
 
               if (selectionMode === "specific") {
@@ -228,6 +231,18 @@ export function TestTab({
               <li>• Results will appear in the evaluations list</li>
               <li>• Costs will be tracked and reported</li>
             </ul>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="notifyOnComplete"
+              name="notifyOnComplete"
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <label htmlFor="notifyOnComplete" className="text-sm text-gray-700">
+              Email me when this batch completes
+            </label>
           </div>
 
           <div className="flex justify-end gap-3">

--- a/internal-packages/db/prisma/migrations/20260302000000_add_batch_completion_and_notification_fields/migration.sql
+++ b/internal-packages/db/prisma/migrations/20260302000000_add_batch_completion_and_notification_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "AgentEvalBatch" ADD COLUMN "completedAt" TIMESTAMP(3),
+ADD COLUMN "notifyOnComplete" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "notifiedAt" TIMESTAMP(3);

--- a/internal-packages/db/prisma/schema.prisma
+++ b/internal-packages/db/prisma/schema.prisma
@@ -238,6 +238,9 @@ model AgentEvalBatch {
   trackingId           String?
   description          String?
   expiresAt            DateTime?
+  completedAt          DateTime?
+  notifyOnComplete     Boolean    @default(false)
+  notifiedAt           DateTime?
   isEphemeral          Boolean    @default(false)
   ephemeralAgent       Agent?     @relation("EphemeralAgent")
   agent                Agent      @relation(fields: [agentId], references: [id], onDelete: Cascade, onUpdate: Cascade)

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -94,6 +94,24 @@ export interface UpdateJobStatusData {
   attempts?: number;
 }
 
+export interface BatchCompletionResult {
+  id: string;
+  completedAt: Date;
+}
+
+export interface BatchNotificationData {
+  id: string;
+  name: string | null;
+  agentId: string;
+  agentName: string;
+  notifyOnComplete: boolean;
+  notifiedAt: Date | null;
+  userEmail: string | null;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
+}
+
 export interface StaleJobCriteria {
   status: JobStatus;
   thresholdMs: number;
@@ -114,6 +132,9 @@ export interface JobRepositoryInterface {
   findJobsForCostUpdate(limit: number, maxAgeHours?: number): Promise<JobEntity[]>;
   updateCost(id: string, cost: number): Promise<JobEntity>;
   findStaleJobs(criteria: StaleJobCriteria[]): Promise<StaleJobResult[]>;
+  tryMarkBatchCompleted(batchId: string): Promise<BatchCompletionResult | null>;
+  getBatchForNotification(batchId: string): Promise<BatchNotificationData | null>;
+  markBatchNotified(batchId: string): Promise<void>;
 }
 
 export class JobRepository implements JobRepositoryInterface {
@@ -308,6 +329,76 @@ export class JobRepository implements JobRepositoryInterface {
   /**
    * Convert database record with relations to job with relations
    */
+  /**
+   * Atomically mark a batch as completed if all jobs are in terminal states.
+   * Returns the batch ID if this call "won" the completion, null otherwise.
+   * The `completedAt IS NULL` condition prevents duplicate completions.
+   */
+  async tryMarkBatchCompleted(batchId: string): Promise<BatchCompletionResult | null> {
+    const result = await this.prisma.$queryRaw<BatchCompletionResult[]>`
+      UPDATE "AgentEvalBatch"
+      SET "completedAt" = NOW()
+      WHERE id = ${batchId}
+        AND "completedAt" IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "Job"
+          WHERE "agentEvalBatchId" = ${batchId}
+            AND status IN ('PENDING', 'RUNNING')
+        )
+      RETURNING id, "completedAt"
+    `;
+
+    return result.length > 0 ? result[0] : null;
+  }
+
+  /**
+   * Fetch batch data needed for sending completion notifications.
+   */
+  async getBatchForNotification(batchId: string): Promise<BatchNotificationData | null> {
+    const batch = await this.prisma.agentEvalBatch.findUnique({
+      where: { id: batchId },
+      include: {
+        user: { select: { email: true } },
+        agent: {
+          include: {
+            versions: { orderBy: { version: 'desc' as const }, take: 1, select: { name: true } },
+          },
+        },
+        jobs: { select: { status: true } },
+      },
+    });
+
+    if (!batch) return null;
+
+    const completedCount = batch.jobs.filter(j => j.status === 'COMPLETED').length;
+    const failedCount = batch.jobs.filter(j => j.status === 'FAILED').length;
+
+    return {
+      id: batch.id,
+      name: batch.name,
+      agentId: batch.agentId,
+      agentName: batch.agent.versions[0]?.name || 'Unknown Agent',
+      notifyOnComplete: batch.notifyOnComplete,
+      notifiedAt: batch.notifiedAt,
+      userEmail: batch.user.email,
+      completedCount,
+      failedCount,
+      totalCount: batch.jobs.length,
+    };
+  }
+
+  /**
+   * Atomically mark a batch as notified (prevents duplicate emails).
+   */
+  async markBatchNotified(batchId: string): Promise<void> {
+    await this.prisma.$queryRaw`
+      UPDATE "AgentEvalBatch"
+      SET "notifiedAt" = NOW()
+      WHERE id = ${batchId}
+        AND "notifiedAt" IS NULL
+    `;
+  }
+
   private toJobWithRelations(job: any): JobWithRelations {
     return {
       ...this.toDomainEntity(job),

--- a/internal-packages/jobs/package.json
+++ b/internal-packages/jobs/package.json
@@ -29,7 +29,8 @@
     "@roast/db": "workspace:*",
     "@roast/domain": "workspace:*",
     "dotenv": "^17.2.0",
-    "pg-boss": "^12.2.0"
+    "pg-boss": "^12.2.0",
+    "resend": "^6.9.3"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",

--- a/internal-packages/jobs/src/cli/process-pgboss-worker.ts
+++ b/internal-packages/jobs/src/cli/process-pgboss-worker.ts
@@ -31,6 +31,8 @@ import { isRetryableError } from '../errors/retryableErrors';
 import { getAgentTimeout } from '../config/agentTimeouts';
 import { updateJobCostsFromHelicone } from '../scheduled-tasks/helicone-poller';
 import { JobReconciliationService } from '../scheduled-tasks/job-reconciliation';
+import { EmailService } from '../core/EmailService';
+import { BatchNotificationHandler } from '../core/BatchNotificationHandler';
 
 interface JobWithAgentVersions {
   evaluation: {
@@ -58,6 +60,16 @@ class PgBossWorker {
     this.jobService = new JobService(this.jobRepository, logger, this.pgBossService);
     this.jobOrchestrator = new JobOrchestrator(this.jobRepository, logger, this.jobService);
     this.jobReconciliationService = new JobReconciliationService(this.jobRepository, this.pgBossService, logger);
+
+    // Wire up batch completion email notifications
+    const emailService = new EmailService(logger);
+    if (emailService.isConfigured) {
+      const notificationHandler = new BatchNotificationHandler(this.jobRepository, emailService, logger);
+      this.jobService.setBatchCompletionHandler(notificationHandler);
+      logger.info('Email notifications enabled for batch completions');
+    } else {
+      logger.info('Email not configured, batch completion notifications disabled');
+    }
   }
 
   public async start() {

--- a/internal-packages/jobs/src/core/BatchNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/BatchNotificationHandler.ts
@@ -1,0 +1,53 @@
+/**
+ * BatchNotificationHandler
+ *
+ * Implements the BatchCompletionHandler interface to send email
+ * notifications when batches complete. Used by the worker process.
+ */
+
+import type { JobRepository } from '@roast/db';
+import type { BatchCompletionHandler } from './JobService';
+import type { EmailService } from './EmailService';
+import type { Logger } from '../types';
+
+export class BatchNotificationHandler implements BatchCompletionHandler {
+  constructor(
+    private jobRepository: JobRepository,
+    private emailService: EmailService,
+    private logger: Logger
+  ) {}
+
+  async onBatchCompleted(batchId: string): Promise<void> {
+    if (!this.emailService.isConfigured) return;
+
+    try {
+      const batch = await this.jobRepository.getBatchForNotification(batchId);
+      if (!batch) return;
+      if (!batch.notifyOnComplete) return;
+      if (batch.notifiedAt) return;
+
+      if (!batch.userEmail) {
+        this.logger.warn(`Batch ${batchId} notification requested but user has no email`);
+        return;
+      }
+
+      const emailSent = await this.emailService.sendBatchCompletionEmail({
+        recipientEmail: batch.userEmail,
+        batchName: batch.name,
+        agentName: batch.agentName,
+        agentId: batch.agentId,
+        completedCount: batch.completedCount,
+        failedCount: batch.failedCount,
+        totalCount: batch.totalCount,
+        batchId: batch.id,
+      });
+
+      if (emailSent) {
+        await this.jobRepository.markBatchNotified(batchId);
+      }
+    } catch (error) {
+      // Email notification failure must not affect job processing
+      this.logger.error(`Failed to send notification for batch ${batchId}:`, error);
+    }
+  }
+}

--- a/internal-packages/jobs/src/core/EmailService.ts
+++ b/internal-packages/jobs/src/core/EmailService.ts
@@ -1,0 +1,108 @@
+/**
+ * EmailService
+ *
+ * Sends transactional emails via Resend.
+ * Used by the worker to notify users when batches complete.
+ */
+
+import { Resend } from 'resend';
+import { config } from '@roast/domain';
+import type { Logger } from '../types';
+
+export interface BatchCompletionEmailData {
+  recipientEmail: string;
+  batchName: string | null;
+  agentName: string;
+  agentId: string;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
+  batchId: string;
+}
+
+export class EmailService {
+  private resend: Resend | null = null;
+
+  constructor(private logger: Logger) {
+    const apiKey = config.auth.resendKey;
+    if (apiKey) {
+      this.resend = new Resend(apiKey);
+    }
+  }
+
+  get isConfigured(): boolean {
+    return this.resend !== null && !!config.auth.emailFrom;
+  }
+
+  async sendBatchCompletionEmail(data: BatchCompletionEmailData): Promise<boolean> {
+    if (!this.isConfigured || !this.resend) {
+      this.logger.warn('Email not configured, skipping batch completion notification');
+      return false;
+    }
+
+    const baseUrl = config.auth.nextAuthUrl || 'https://roastmypost.com';
+    const batchUrl = `${baseUrl}/evaluators/${data.agentId}`;
+    const batchLabel = data.batchName || `Batch ${data.batchId.slice(0, 8)}`;
+    const successRate = data.totalCount > 0
+      ? Math.round((data.completedCount / data.totalCount) * 100)
+      : 0;
+
+    const subject = `Batch complete: ${batchLabel} (${successRate}% success)`;
+
+    const html = `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #1a1a1a; margin-bottom: 16px;">Batch Evaluation Complete</h2>
+        <p style="color: #4a4a4a; margin-bottom: 24px;">
+          Your evaluation batch <strong>${escapeHtml(batchLabel)}</strong> for agent <strong>${escapeHtml(data.agentName)}</strong> has finished.
+        </p>
+        <table style="border-collapse: collapse; width: 100%; margin-bottom: 24px;">
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Completed</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.completedCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Failed</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.failedCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Total</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.totalCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Success Rate</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${successRate}%</td>
+          </tr>
+        </table>
+        <a href="${batchUrl}" style="display: inline-block; background: #2563eb; color: #ffffff; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 500;">
+          View Results
+        </a>
+        <p style="color: #9a9a9a; font-size: 12px; margin-top: 32px;">
+          You received this email because you checked "Email me when this batch completes" when creating the batch.
+        </p>
+      </div>
+    `;
+
+    try {
+      await this.resend.emails.send({
+        from: config.auth.emailFrom!,
+        to: data.recipientEmail,
+        subject,
+        html,
+      });
+
+      this.logger.info(`Batch completion email sent for batch ${data.batchId} to ${data.recipientEmail}`);
+      return true;
+    } catch (error) {
+      this.logger.error(`Failed to send batch completion email for batch ${data.batchId}:`, error);
+      return false;
+    }
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -13,12 +13,26 @@ import { PgBossService } from './PgBossService';
 import { DOCUMENT_EVALUATION_JOB } from '../types/jobTypes';
 import type { Logger } from '../types';
 
+export interface BatchCompletionHandler {
+  onBatchCompleted(batchId: string): Promise<void>;
+}
+
 export class JobService {
+  private batchCompletionHandler?: BatchCompletionHandler;
+
   constructor(
     private jobRepository: JobRepository,
     private logger: Logger,
     private pgBossService: PgBossService
   ) {}
+
+  /**
+   * Set an optional handler that is called when a batch completes.
+   * Used by the worker to trigger email notifications.
+   */
+  setBatchCompletionHandler(handler: BatchCompletionHandler): void {
+    this.batchCompletionHandler = handler;
+  }
 
   async initialize() {
     await this.pgBossService.initialize();
@@ -98,7 +112,9 @@ export class JobService {
     }
 
     // Update database to mark as cancelled
-    return this.markAsCancelled(jobId);
+    const cancelledJob = await this.markAsCancelled(jobId);
+    await this.checkBatchCompletion(cancelledJob);
+    return cancelledJob;
   }
 
   /**
@@ -137,24 +153,48 @@ export class JobService {
       logs: string;
     }
   ) {
-    return this.jobRepository.updateStatus(jobId, {
+    const completedJob = await this.jobRepository.updateStatus(jobId, {
       status: JobStatus.COMPLETED,
       completedAt: new Date(),
       llmThinking: data.llmThinking,
       durationInSeconds: data.durationInSeconds,
       logs: data.logs,
     });
+    await this.checkBatchCompletion(completedJob);
+    return completedJob;
   }
 
   /**
    * Mark a job as failed
    */
   async markAsFailed(jobId: string, error: unknown): Promise<JobEntity> {
-    return this.jobRepository.updateStatus(jobId, {
+    const failedJob = await this.jobRepository.updateStatus(jobId, {
       status: JobStatus.FAILED,
       error: error instanceof Error ? error.message : String(error),
       completedAt: new Date(),
     });
+    await this.checkBatchCompletion(failedJob);
+    return failedJob;
   }
 
+  /**
+   * Check if a job's batch is now complete (all jobs in terminal states).
+   * Uses an atomic UPDATE to ensure only one worker detects completion.
+   */
+  private async checkBatchCompletion(job: JobEntity): Promise<void> {
+    if (!job.agentEvalBatchId) return;
+
+    try {
+      const result = await this.jobRepository.tryMarkBatchCompleted(job.agentEvalBatchId);
+      if (result) {
+        this.logger.info(`Batch ${result.id} completed at ${result.completedAt.toISOString()}`);
+        if (this.batchCompletionHandler) {
+          await this.batchCompletionHandler.onBatchCompleted(result.id);
+        }
+      }
+    } catch (error) {
+      // Batch completion tracking is non-critical — don't fail the job
+      this.logger.error(`Failed to check batch completion for batch ${job.agentEvalBatchId}:`, error);
+    }
+  }
 }

--- a/internal-packages/jobs/src/index.ts
+++ b/internal-packages/jobs/src/index.ts
@@ -5,7 +5,9 @@
 // Core services
 export { JobOrchestrator, type JobOrchestratorInterface } from './core/JobOrchestrator';
 export { PgBossService } from './core/PgBossService';
-export { JobService } from './core/JobService';
+export { JobService, type BatchCompletionHandler } from './core/JobService';
+export { EmailService, type BatchCompletionEmailData } from './core/EmailService';
+export { BatchNotificationHandler } from './core/BatchNotificationHandler';
 
 // Job types
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       pg-boss:
         specifier: ^12.2.0
         version: 12.2.0
+      resend:
+        specifier: ^6.9.3
+        version: 6.9.3
     devDependencies:
       '@types/node':
         specifier: ^20.11.5
@@ -2664,6 +2667,9 @@ packages:
   '@sinclair/typebox@0.34.38':
     resolution: {integrity: sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -4115,6 +4121,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
@@ -5101,6 +5110,7 @@ packages:
   next@15.3.6:
     resolution: {integrity: sha512-oI6D1zbbsh6JzzZFDCSHnnx6Qpvd1fSkVJu/5d8uluqnxzuoqtodVZjYvNovooznUq8udSAiKp7MbwlfZ8Gm6w==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -5379,6 +5389,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postal-mime@2.7.3:
+    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -5729,6 +5742,15 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  resend@6.9.3:
+    resolution: {integrity: sha512-GRXjH9XZBJA+daH7bBVDuTShr22iWCxXA8P7t495G4dM/RC+d+3gHBK/6bz9K6Vpcq11zRQKmD+B+jECwQlyGQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -5968,6 +5990,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -6095,6 +6120,9 @@ packages:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  svix@1.84.1:
+    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -6460,6 +6488,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -6595,6 +6627,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -9391,6 +9424,8 @@ snapshots:
   '@sinclair/typebox@0.34.38':
     optional: true
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -9936,7 +9971,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11153,6 +11188,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.0.6: {}
 
@@ -12702,6 +12739,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.3: {}
+
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -13041,6 +13080,11 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  resend@6.9.3:
+    dependencies:
+      postal-mime: 2.7.3
+      svix: 1.84.1
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -13357,6 +13401,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.1: {}
 
   std-env@3.9.0: {}
@@ -13514,6 +13563,11 @@ snapshots:
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
+
+  svix@1.84.1:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -13923,6 +13977,8 @@ snapshots:
       react: 19.2.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
## Summary

- **Batch completion detection**: Adds `completedAt` field to `AgentEvalBatch` with an atomic SQL `UPDATE...WHERE completedAt IS NULL AND NOT EXISTS (pending/running jobs)...RETURNING` pattern that prevents duplicate completion events from concurrent workers
- **Email notifications**: Integrates Resend SDK into the job worker to send batch completion emails when users opt in via a new "Email me when this batch completes" checkbox
- **Bug fixes**: Fixes `isComplete` in batches API (previously only counted COMPLETED jobs, ignoring FAILED; also returned false for null targetCount). Refactors admin cancel route to use `JobService` so batch completion checks fire on cancellations.

Closes #400, Closes #401

## Changes

### Schema & Migration
- Added `completedAt`, `notifyOnComplete`, `notifiedAt` fields to `AgentEvalBatch`

### Infrastructure (`@roast/jobs`, `@roast/db`)
- `JobRepository.tryMarkBatchCompleted()` — atomic idempotent completion check
- `JobRepository.getBatchForNotification()` / `markBatchNotified()` — notification data + dedup
- `JobService.checkBatchCompletion()` — called after `markAsCompleted`, `markAsFailed`, `cancelJob`
- `BatchCompletionHandler` interface — injected by worker, not web app
- `EmailService` — Resend wrapper with `isConfigured` for graceful dev degradation
- `BatchNotificationHandler` — orchestrates check → email → mark notified

### UI & API
- Checkbox in TestTab batch creation form
- `notifyOnComplete` accepted in eval-batch API
- `isComplete` in batches API now uses `completedAt !== null`
- Admin cancel route uses `JobService.cancelJob()` instead of direct Prisma

## Test plan

- [ ] Run migration on database
- [ ] Create a batch with "Email me" checked, verify email arrives after last job completes
- [ ] Create a batch without checkbox, verify no email sent
- [ ] Cancel a job via admin monitor, verify batch still detects completion correctly
- [ ] Verify batches list shows `isComplete: true` for completed batches
- [ ] Test with user without email — verify graceful skip in worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now opt-in to receive email notifications when evaluation batches complete via a new "Email me when this batch completes" checkbox in the batch testing form.

* **Improvements**
  * Enhanced batch completion tracking and progress calculation for more accurate batch status updates.
  * Improved job cancellation workflow for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->