### PR TITLE
feat: Document-level email notifications for evaluation completion

### DIFF
--- a/apps/web/src/app/api/evaluators/[agentId]/batches/route.ts
+++ b/apps/web/src/app/api/evaluators/[agentId]/batches/route.ts
@@ -81,7 +81,8 @@ export async function GET(
         ? gradesWithValues.reduce((sum, grade) => sum + grade, 0) / gradesWithValues.length 
         : null;
 
-      const progress = batch.targetCount ? (jobStats.completed / batch.targetCount) * 100 : 0;
+      const terminalCount = jobStats.completed + jobStats.failed;
+      const progress = jobStats.total > 0 ? (terminalCount / jobStats.total) * 100 : 0;
 
       return {
         id: batch.id,
@@ -96,7 +97,7 @@ export async function GET(
         totalCost,
         avgDuration: Math.round(avgDuration),
         avgGrade,
-        isComplete: batch.targetCount ? completedJobs.length === batch.targetCount : false,
+        isComplete: batch.completedAt !== null,
       };
     });
 

--- a/apps/web/src/app/api/evaluators/[agentId]/eval-batch/route.ts
+++ b/apps/web/src/app/api/evaluators/[agentId]/eval-batch/route.ts
@@ -8,6 +8,7 @@ interface CreateBatchRequest {
   name?: string;
   targetCount?: number;
   documentIds?: string[];
+  notifyOnComplete?: boolean;
 }
 
 export async function POST(
@@ -174,6 +175,7 @@ export async function POST(
         targetCount: targetCount,
         requestedDocumentIds: requestedDocumentIds,
         userId: userId,
+        notifyOnComplete: body.notifyOnComplete ?? false,
       },
     });
 

--- a/apps/web/src/app/api/monitor/jobs/[jobId]/cancel/route.ts
+++ b/apps/web/src/app/api/monitor/jobs/[jobId]/cancel/route.ts
@@ -5,6 +5,7 @@ import { JobStatus } from "@roast/db";
 import { authenticateRequest } from "@/infrastructure/auth/auth-helpers";
 import { commonErrors } from "@/infrastructure/http/api-response-helpers";
 import { isAdmin } from "@/infrastructure/auth/auth";
+import { getServices } from "@/application/services/ServiceFactory";
 
 export async function POST(
   request: NextRequest,
@@ -14,16 +15,16 @@ export async function POST(
   if (!userId) {
     return commonErrors.unauthorized();
   }
-  
+
   // Check if user is admin
   const adminCheck = await isAdmin();
   if (!adminCheck) {
     return commonErrors.forbidden();
   }
-  
+
   try {
     const { jobId } = await params;
-    
+
     // Parse request body for optional cancellation reason
     let cancellationReason: string | undefined;
     try {
@@ -32,20 +33,20 @@ export async function POST(
     } catch {
       // No body or invalid JSON is fine, reason is optional
     }
-    
+
     // Get the current job status
     const job = await prisma.job.findUnique({
       where: { id: jobId },
       select: { status: true }
     });
-    
+
     if (!job) {
       return NextResponse.json(
         { error: "Job not found" },
         { status: 404 }
       );
     }
-    
+
     // Only allow cancelling PENDING or RUNNING jobs
     if (job.status !== JobStatus.PENDING && job.status !== JobStatus.RUNNING) {
       return NextResponse.json(
@@ -53,16 +54,17 @@ export async function POST(
         { status: 400 }
       );
     }
-    
-    // Update the job with cancellation info
+
+    // Cancel via JobService (handles pg-boss + DB + batch completion check)
+    const { jobService } = getServices();
+    await jobService.cancelJob(jobId);
+
+    // Set admin-specific fields (cancelledById, custom reason)
     const updatedJob = await prisma.job.update({
       where: { id: jobId },
       data: {
-        status: JobStatus.CANCELLED,
-        cancelledAt: new Date(),
         cancelledById: userId,
-        cancellationReason,
-        completedAt: new Date(), // Set completion time for cancelled jobs
+        ...(cancellationReason && { cancellationReason }),
       },
       include: {
         cancelledBy: {
@@ -74,13 +76,13 @@ export async function POST(
         }
       }
     });
-    
+
     logger.info(`Job ${jobId} cancelled by admin ${userId}`, {
       jobId,
       adminId: userId,
       reason: cancellationReason || "No reason provided"
     });
-    
+
     return NextResponse.json({
       success: true,
       job: {
@@ -91,7 +93,7 @@ export async function POST(
         cancellationReason: updatedJob.cancellationReason,
       }
     });
-    
+
   } catch (error) {
     logger.error('Error cancelling job:', error);
     return commonErrors.serverError("Failed to cancel job");

--- a/apps/web/src/app/docs/[docId]/actions/evaluation-actions.ts
+++ b/apps/web/src/app/docs/[docId]/actions/evaluation-actions.ts
@@ -8,6 +8,7 @@ import { auth } from "@/infrastructure/auth/auth";
 import { DocumentModel } from "@/models/Document";
 import { validateServerActionAccess } from "@/infrastructure/http/guards";
 import { chargeQuotaForServerAction } from "@/infrastructure/rate-limiting/server-action-helpers";
+import { getServices } from "@/application/services/ServiceFactory";
 
 /**
  * Creates a new job for an evaluation, allowing it to be re-run
@@ -134,18 +135,16 @@ export async function setDocumentNotification(
       return { success: false, error: "User must be logged in" };
     }
 
-    const document = await prisma.document.findFirst({
-      where: { id: documentId, submittedById: session.user.id },
-    });
+    const { documentService } = getServices();
+    const result = await documentService.setNotifyOnComplete(
+      documentId,
+      session.user.id,
+      notifyOnComplete
+    );
 
-    if (!document) {
-      return { success: false, error: "Document not found or not owned by you" };
+    if (result.isError()) {
+      return { success: false, error: result.error()?.message || "Failed to update notification preference" };
     }
-
-    await prisma.document.update({
-      where: { id: documentId },
-      data: { notifyOnComplete },
-    });
 
     revalidatePath(`/docs/${documentId}`);
     return { success: true };

--- a/apps/web/src/app/docs/[docId]/actions/evaluation-actions.ts
+++ b/apps/web/src/app/docs/[docId]/actions/evaluation-actions.ts
@@ -121,6 +121,44 @@ export async function createOrRerunEvaluation(
 }
 
 /**
+ * Toggle email notification for document evaluation completion
+ */
+export async function setDocumentNotification(
+  documentId: string,
+  notifyOnComplete: boolean
+) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return { success: false, error: "User must be logged in" };
+    }
+
+    const document = await prisma.document.findFirst({
+      where: { id: documentId, submittedById: session.user.id },
+    });
+
+    if (!document) {
+      return { success: false, error: "Document not found or not owned by you" };
+    }
+
+    await prisma.document.update({
+      where: { id: documentId },
+      data: { notifyOnComplete },
+    });
+
+    revalidatePath(`/docs/${documentId}`);
+    return { success: true };
+  } catch (error) {
+    logger.error("Error updating notification preference:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update notification preference",
+    };
+  }
+}
+
+/**
  * Deletes an evaluation and all its related data
  */
 export async function deleteEvaluation(

--- a/apps/web/src/app/docs/[docId]/components/EvaluationManagement.tsx
+++ b/apps/web/src/app/docs/[docId]/components/EvaluationManagement.tsx
@@ -12,6 +12,7 @@ import {
   setDocumentNotification,
 } from "@/app/docs/[docId]/actions/evaluation-actions";
 import { AgentBadges } from "@/components/AgentBadges";
+import { NotificationCheckbox } from "@/components/NotificationCheckbox";
 import { AgentIcon } from "@/components/AgentIcon";
 import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/constants/routes";
@@ -152,17 +153,12 @@ export function EvaluationManagement({
 
       {/* Email notification toggle */}
       {isOwner && evaluations.length > 0 && (
-        <div className="mb-8 flex items-center gap-2">
-          <input
-            type="checkbox"
+        <div className="mb-8">
+          <NotificationCheckbox
             id="notify-on-complete"
             checked={notifyOnComplete}
-            onChange={(e) => handleNotifyToggle(e.target.checked)}
-            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            onChange={handleNotifyToggle}
           />
-          <label htmlFor="notify-on-complete" className="text-sm text-gray-700">
-            Email me when evaluations complete
-          </label>
         </div>
       )}
 

--- a/apps/web/src/app/docs/[docId]/components/EvaluationManagement.tsx
+++ b/apps/web/src/app/docs/[docId]/components/EvaluationManagement.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import {
   createOrRerunEvaluation,
   deleteEvaluation,
+  setDocumentNotification,
 } from "@/app/docs/[docId]/actions/evaluation-actions";
 import { AgentBadges } from "@/components/AgentBadges";
 import { AgentIcon } from "@/components/AgentIcon";
@@ -35,6 +36,7 @@ interface EvaluationManagementProps {
   evaluations: Array<Evaluation & { jobs?: Array<{ status: string }> }>;
   availableAgents: Agent[];
   isOwner: boolean;
+  notifyOnComplete: boolean;
 }
 
 export function EvaluationManagement({
@@ -42,6 +44,7 @@ export function EvaluationManagement({
   evaluations,
   availableAgents,
   isOwner,
+  notifyOnComplete: initialNotify,
 }: EvaluationManagementProps) {
   const router = useRouter();
   const { handleRerun, runningEvals } = useEvaluationRerun({
@@ -50,6 +53,15 @@ export function EvaluationManagement({
   const [runningAgents, setRunningAgents] = useState<Set<string>>(new Set());
   const [deletingEvals, setDeletingEvals] = useState<Set<string>>(new Set());
   const [sortedAgents, setSortedAgents] = useState<Agent[]>([]);
+  const [notifyOnComplete, setNotifyOnComplete] = useState(initialNotify);
+
+  const handleNotifyToggle = async (checked: boolean) => {
+    setNotifyOnComplete(checked);
+    const result = await setDocumentNotification(docId, checked);
+    if (!result.success) {
+      setNotifyOnComplete(!checked); // revert on failure
+    }
+  };
 
   // Sort available agents: recommended first, then regular, then deprecated
   useEffect(() => {
@@ -137,6 +149,22 @@ export function EvaluationManagement({
           )}
         </div>
       </div>
+
+      {/* Email notification toggle */}
+      {isOwner && evaluations.length > 0 && (
+        <div className="mb-8 flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="notify-on-complete"
+            checked={notifyOnComplete}
+            onChange={(e) => handleNotifyToggle(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <label htmlFor="notify-on-complete" className="text-sm text-gray-700">
+            Email me when evaluations complete
+          </label>
+        </div>
+      )}
 
       {/* Add More Agents */}
       {isOwner && sortedAgents.length > 0 && (

--- a/apps/web/src/app/docs/[docId]/edit/page.tsx
+++ b/apps/web/src/app/docs/[docId]/edit/page.tsx
@@ -137,8 +137,9 @@ export default function EditDocumentPage({ params }: Props) {
           submitterNotes: document.submitterNotes || "",
         });
         
-        // Update the local state for privacy
+        // Update the local state for privacy and notification
         setIsPrivate(document.isPrivate ?? false);
+        setNotifyOnComplete(document.notifyOnComplete ?? false);
 
         // Count the number of evaluations
         const evalCount = document.reviews?.length || 0;

--- a/apps/web/src/app/docs/[docId]/edit/page.tsx
+++ b/apps/web/src/app/docs/[docId]/edit/page.tsx
@@ -27,6 +27,7 @@ import {
   documentSchema,
 } from "@/app/docs/new/schema";
 import { updateDocument } from "./actions";
+import { setDocumentNotification } from "../actions/evaluation-actions";
 
 interface FormFieldConfig {
   name: keyof DocumentInput;
@@ -87,6 +88,7 @@ export default function EditDocumentPage({ params }: Props) {
   const [evaluationCount, setEvaluationCount] = useState(0);
   const [pendingFormData, setPendingFormData] = useState<DocumentInput | null>(null);
   const [_isPrivate, setIsPrivate] = useState(false);
+  const [notifyOnComplete, setNotifyOnComplete] = useState(false);
 
   const methods = useForm<DocumentInput>({
     defaultValues: {
@@ -157,10 +159,13 @@ export default function EditDocumentPage({ params }: Props) {
 
   const handleConfirmUpdate = async () => {
     if (!pendingFormData) return;
-    
+
     setShowWarningDialog(false);
-    
+
     try {
+      // Set notification preference before update triggers re-evaluations
+      await setDocumentNotification(docId, notifyOnComplete);
+
       const updateResult = await updateDocument({
         ...pendingFormData,
         docId: docId,
@@ -369,6 +374,21 @@ export default function EditDocumentPage({ params }: Props) {
                   </div>
                 </RadioGroup>
               </FormField>
+
+              {evaluationCount > 0 && (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="edit-notify"
+                    checked={notifyOnComplete}
+                    onChange={(e) => setNotifyOnComplete(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <label htmlFor="edit-notify" className="text-sm text-gray-700">
+                    Email me when re-evaluations complete
+                  </label>
+                </div>
+              )}
 
               {errors.root && (
                 <div className="rounded-md bg-red-50 p-4">

--- a/apps/web/src/app/docs/[docId]/edit/page.tsx
+++ b/apps/web/src/app/docs/[docId]/edit/page.tsx
@@ -26,6 +26,7 @@ import {
   type DocumentInput,
   documentSchema,
 } from "@/app/docs/new/schema";
+import { NotificationCheckbox } from "@/components/NotificationCheckbox";
 import { updateDocument } from "./actions";
 import { setDocumentNotification } from "../actions/evaluation-actions";
 
@@ -377,18 +378,12 @@ export default function EditDocumentPage({ params }: Props) {
               </FormField>
 
               {evaluationCount > 0 && (
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="edit-notify"
-                    checked={notifyOnComplete}
-                    onChange={(e) => setNotifyOnComplete(e.target.checked)}
-                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <label htmlFor="edit-notify" className="text-sm text-gray-700">
-                    Email me when re-evaluations complete
-                  </label>
-                </div>
+                <NotificationCheckbox
+                  id="edit-notify"
+                  checked={notifyOnComplete}
+                  onChange={setNotifyOnComplete}
+                  label="Email me when re-evaluations complete"
+                />
               )}
 
               {errors.root && (

--- a/apps/web/src/app/docs/[docId]/page.tsx
+++ b/apps/web/src/app/docs/[docId]/page.tsx
@@ -92,6 +92,7 @@ export default async function DocumentPage({
   const documentWithBatch = await prisma.document.findUnique({
     where: { id: docId },
     select: {
+      notifyOnComplete: true,
       ephemeralBatch: {
         select: {
           trackingId: true,
@@ -351,6 +352,7 @@ export default async function DocumentPage({
                 evaluations={document.reviews || []}
                 availableAgents={availableAgents}
                 isOwner={isOwner}
+                notifyOnComplete={documentWithBatch?.notifyOnComplete ?? false}
               />
             </div>
           </div>

--- a/apps/web/src/app/docs/import/actions.ts
+++ b/apps/web/src/app/docs/import/actions.ts
@@ -8,7 +8,7 @@ import { logger } from "@/infrastructure/logging/logger";
 import { validateServerActionAccess } from "@/infrastructure/http/guards";
 import { chargeQuotaForServerAction } from "@/infrastructure/rate-limiting/server-action-helpers";
 
-export async function importDocument(url: string, agentIds: string[] = [], isPrivate: boolean = true) {
+export async function importDocument(url: string, agentIds: string[] = [], isPrivate: boolean = true, notifyOnComplete: boolean = false) {
   try {
     // Get the current user session
     const session = await auth();
@@ -29,7 +29,7 @@ export async function importDocument(url: string, agentIds: string[] = [], isPri
     }
 
     // 2. Do expensive work (fetch, validate)
-    const result = await importDocumentService(url, session.user.id, agentIds, isPrivate);
+    const result = await importDocumentService(url, session.user.id, agentIds, isPrivate, notifyOnComplete);
 
     if (!result.success) {
       throw new Error(result.error || "Failed to import document");

--- a/apps/web/src/app/docs/new/CreateDocumentForm.tsx
+++ b/apps/web/src/app/docs/new/CreateDocumentForm.tsx
@@ -293,6 +293,7 @@ export default function CreateDocumentForm() {
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [importIsPrivate, setImportIsPrivate] = useState(true); // Default to private
+  const [notifyOnComplete, setNotifyOnComplete] = useState(false);
 
   // Agent selection state
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -376,7 +377,7 @@ export default function CreateDocumentForm() {
     try {
       setIsImporting(true);
       setImportError(null);
-      await importDocument(importUrl.trim(), selectedAgentIds, importIsPrivate);
+      await importDocument(importUrl.trim(), selectedAgentIds, importIsPrivate, notifyOnComplete);
     } catch (err) {
       setImportError(
         err instanceof Error ? err.message : "Failed to import document"
@@ -389,7 +390,7 @@ export default function CreateDocumentForm() {
   const onSubmit = async (data: DocumentInput) => {
     try {
       const result = documentSchema.parse(data);
-      await createDocument(result, selectedAgentIds);
+      await createDocument(result, selectedAgentIds, notifyOnComplete);
     } catch (error) {
       // Ignore Next.js redirect errors
       if (error instanceof Error && error.message === "NEXT_REDIRECT") {
@@ -530,6 +531,21 @@ export default function CreateDocumentForm() {
                     />
                   )}
                 </>
+              )}
+
+              {selectedAgentIds.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="import-notify"
+                    checked={notifyOnComplete}
+                    onChange={(e) => setNotifyOnComplete(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <label htmlFor="import-notify" className="text-sm text-gray-700">
+                    Email me when evaluations complete
+                  </label>
+                </div>
               )}
 
               {importError && (
@@ -686,6 +702,21 @@ export default function CreateDocumentForm() {
                       />
                     )}
                   </>
+                )}
+
+                {selectedAgentIds.length > 0 && (
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="manual-notify"
+                      checked={notifyOnComplete}
+                      onChange={(e) => setNotifyOnComplete(e.target.checked)}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <label htmlFor="manual-notify" className="text-sm text-gray-700">
+                      Email me when evaluations complete
+                    </label>
+                  </div>
                 )}
 
                 {errors.root && (

--- a/apps/web/src/app/docs/new/CreateDocumentForm.tsx
+++ b/apps/web/src/app/docs/new/CreateDocumentForm.tsx
@@ -7,6 +7,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { AgentBadges } from "@/components/AgentBadges";
+import { NotificationCheckbox } from "@/components/NotificationCheckbox";
 import { Button } from "@/components/Button";
 import { FormField } from "@/components/FormField";
 import { Label } from "@/components/ui/label";
@@ -534,18 +535,11 @@ export default function CreateDocumentForm() {
               )}
 
               {selectedAgentIds.length > 0 && (
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="import-notify"
-                    checked={notifyOnComplete}
-                    onChange={(e) => setNotifyOnComplete(e.target.checked)}
-                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <label htmlFor="import-notify" className="text-sm text-gray-700">
-                    Email me when evaluations complete
-                  </label>
-                </div>
+                <NotificationCheckbox
+                  id="import-notify"
+                  checked={notifyOnComplete}
+                  onChange={setNotifyOnComplete}
+                />
               )}
 
               {importError && (
@@ -705,18 +699,11 @@ export default function CreateDocumentForm() {
                 )}
 
                 {selectedAgentIds.length > 0 && (
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id="manual-notify"
-                      checked={notifyOnComplete}
-                      onChange={(e) => setNotifyOnComplete(e.target.checked)}
-                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                    />
-                    <label htmlFor="manual-notify" className="text-sm text-gray-700">
-                      Email me when evaluations complete
-                    </label>
-                  </div>
+                  <NotificationCheckbox
+                    id="manual-notify"
+                    checked={notifyOnComplete}
+                    onChange={setNotifyOnComplete}
+                  />
                 )}
 
                 {errors.root && (

--- a/apps/web/src/app/docs/new/actions.ts
+++ b/apps/web/src/app/docs/new/actions.ts
@@ -13,7 +13,7 @@ import { getServices } from "@/application/services/ServiceFactory";
 
 import { type DocumentInput } from "./schema";
 
-export async function createDocument(data: DocumentInput, agentIds: string[] = []) {
+export async function createDocument(data: DocumentInput, agentIds: string[] = [], notifyOnComplete: boolean = false) {
   try {
     const session = await auth();
 
@@ -40,7 +40,8 @@ export async function createDocument(data: DocumentInput, agentIds: string[] = [
         isPrivate: data.isPrivate ?? true,
         submitterNotes: data.submitterNotes
       },
-      agentIds
+      agentIds,
+      notifyOnComplete
     );
 
     if (result.isError()) {

--- a/apps/web/src/application/services/documentImport.ts
+++ b/apps/web/src/application/services/documentImport.ts
@@ -23,7 +23,8 @@ export async function importDocumentService(
   url: string,
   userId: string,
   agentIds: string[] = [],
-  isPrivate: boolean = true
+  isPrivate: boolean = true,
+  notifyOnComplete: boolean = false
 ): Promise<ImportDocumentResult> {
   try {
     logger.info(`🔄 Starting article import for URL: ${url}`);
@@ -71,7 +72,8 @@ export async function importDocumentService(
         importUrl: url,
         isPrivate,
       },
-      agentIds
+      agentIds,
+      notifyOnComplete
     );
 
     if (result.isError()) {

--- a/apps/web/src/components/AgentDetail/tabs/TestTab.tsx
+++ b/apps/web/src/components/AgentDetail/tabs/TestTab.tsx
@@ -67,8 +67,11 @@ export function TestTab({
               const formData = new FormData(e.currentTarget);
               const name = formData.get("name") as string;
 
+              const notifyOnComplete = formData.get("notifyOnComplete") === "on";
+
               let requestBody: any = {
                 name: name || undefined,
+                notifyOnComplete,
               };
 
               if (selectionMode === "specific") {
@@ -228,6 +231,18 @@ export function TestTab({
               <li>• Results will appear in the evaluations list</li>
               <li>• Costs will be tracked and reported</li>
             </ul>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="notifyOnComplete"
+              name="notifyOnComplete"
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <label htmlFor="notifyOnComplete" className="text-sm text-gray-700">
+              Email me when this batch completes
+            </label>
           </div>
 
           <div className="flex justify-end gap-3">

--- a/apps/web/src/components/NotificationCheckbox.tsx
+++ b/apps/web/src/components/NotificationCheckbox.tsx
@@ -1,7 +1,7 @@
 interface NotificationCheckboxProps {
   id: string;
   checked: boolean;
-  onChange: (checked: boolean) => void;
+  onChange: (checked: boolean) => void | Promise<void>;
   label?: string;
 }
 
@@ -17,7 +17,7 @@ export function NotificationCheckbox({
         type="checkbox"
         id={id}
         checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
+        onChange={(e) => void onChange(e.target.checked)}
         className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
       />
       <label htmlFor={id} className="text-sm text-gray-700">

--- a/apps/web/src/components/NotificationCheckbox.tsx
+++ b/apps/web/src/components/NotificationCheckbox.tsx
@@ -1,0 +1,28 @@
+interface NotificationCheckboxProps {
+  id: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: string;
+}
+
+export function NotificationCheckbox({
+  id,
+  checked,
+  onChange,
+  label = "Email me when evaluations complete",
+}: NotificationCheckboxProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="checkbox"
+        id={id}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+      />
+      <label htmlFor={id} className="text-sm text-gray-700">
+        {label}
+      </label>
+    </div>
+  );
+}

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres:17
+    environment:
+      - "POSTGRES_USER=postgres"
+      - "POSTGRES_PASSWORD=postgres"
+    volumes:
+      - type: volume
+        source: postgres-data
+        target: /var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  postgres-data:
+    name: dev-postgres-roast

--- a/dev/scripts/dev-env.sh
+++ b/dev/scripts/dev-env.sh
@@ -5,6 +5,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$HOME/dev/ozzie/dev/docker-compose.yml"
 SESSION_NAME="roast-dev"
 
 start_dev() {
@@ -15,19 +16,29 @@ start_dev() {
 
     cd "$REPO_ROOT"
 
-    # Create new detached session with first window for web
-    tmux new-session -d -s "$SESSION_NAME" -n "dev" -c "$REPO_ROOT"
+    # Window 0 "db": Postgres in foreground
+    tmux new-session -d -s "$SESSION_NAME" -n "db" -c "$REPO_ROOT"
+    tmux send-keys -t "$SESSION_NAME:db" "docker compose -f $COMPOSE_FILE up" Enter
 
-    # Split vertically and run jobs in right pane
-    tmux split-window -h -t "$SESSION_NAME:dev" -c "$REPO_ROOT/internal-packages/jobs"
+    # Wait for Postgres to be ready
+    echo "Waiting for Postgres..."
+    for i in $(seq 1 30); do
+        if docker compose -f "$COMPOSE_FILE" exec -T db pg_isready -U postgres >/dev/null 2>&1; then
+            echo "Postgres ready"
+            break
+        fi
+        sleep 1
+    done
 
-    # Run web dev server in left pane
+    # Window 1 "dev": web (left) + worker (right)
+    tmux new-window -t "$SESSION_NAME" -n "dev" -c "$REPO_ROOT"
     tmux send-keys -t "$SESSION_NAME:dev.0" "pnpm run dev -H 0.0.0.0" Enter
 
-    # Run jobs processor in right pane
+    tmux split-window -h -t "$SESSION_NAME:dev" -c "$REPO_ROOT/internal-packages/jobs"
     tmux send-keys -t "$SESSION_NAME:dev.1" "NODE_ENV=development pnpm run process-pgboss" Enter
 
-    # Select left pane
+    # Start on the dev window
+    tmux select-window -t "$SESSION_NAME:dev"
     tmux select-pane -t "$SESSION_NAME:dev.0"
 
     echo "Dev session '$SESSION_NAME' started"
@@ -42,6 +53,8 @@ stop_dev() {
     else
         echo "Session '$SESSION_NAME' is not running."
     fi
+    # Stop Postgres container
+    docker compose -f "$COMPOSE_FILE" stop 2>/dev/null
 }
 
 status_dev() {
@@ -70,14 +83,14 @@ restart_dev() {
 
     echo "Restarting dev environment..."
 
-    # Send Ctrl+C to both panes to kill running processes
+    # Send Ctrl+C to web and worker panes (not postgres)
     tmux send-keys -t "$SESSION_NAME:dev.0" C-c
     tmux send-keys -t "$SESSION_NAME:dev.1" C-c
 
     # Wait a moment for processes to die
     sleep 1
 
-    # Clear visible screen and scrollback buffer in both panes
+    # Clear visible screen and scrollback buffer in web and worker panes
     tmux send-keys -t "$SESSION_NAME:dev.0" "clear" Enter
     tmux send-keys -t "$SESSION_NAME:dev.1" "clear" Enter
     sleep 0.2

--- a/dev/scripts/dev-env.sh
+++ b/dev/scripts/dev-env.sh
@@ -5,7 +5,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-COMPOSE_FILE="$HOME/dev/ozzie/dev/docker-compose.yml"
+COMPOSE_FILE="$REPO_ROOT/dev/docker-compose.dev.yml"
 SESSION_NAME="roast-dev"
 
 start_dev() {

--- a/dev/scripts/lint-pr-strict.sh
+++ b/dev/scripts/lint-pr-strict.sh
@@ -1,24 +1,25 @@
 #!/usr/bin/env bash
 
-# Strict ESLint check for PR changed files only
+# Strict ESLint check for TypeScript files
 #
-# Runs strict type-aware ESLint rules on files changed in the current branch
-# compared to main. Catches real bugs without pedantic style rules.
+# Runs strict type-aware ESLint rules that catch real bugs.
+# Can check PR-changed files or all files in a directory.
 #
 # Usage:
 #   ./dev/scripts/lint-pr-strict.sh [options] [path-filter]
 #
 # Options:
+#   -a, --all              Check ALL files in path (not just PR-changed)
 #   -b, --base <branch>    Base branch to compare against (default: origin/main)
 #   -l, --list             List files that would be checked, don't run lint
 #   -h, --help             Show this help message
 #
 # Examples:
-#   ./dev/scripts/lint-pr-strict.sh                          # All changed files
-#   ./dev/scripts/lint-pr-strict.sh internal-packages/ai     # Only ai package
-#   ./dev/scripts/lint-pr-strict.sh apps/web                 # Only web app
+#   ./dev/scripts/lint-pr-strict.sh                          # PR-changed files
+#   ./dev/scripts/lint-pr-strict.sh apps/web                 # PR-changed in web
+#   ./dev/scripts/lint-pr-strict.sh -a apps/web/src/app      # ALL files in dir
+#   ./dev/scripts/lint-pr-strict.sh -a internal-packages/jobs # ALL files in jobs
 #   ./dev/scripts/lint-pr-strict.sh -l                       # List files only
-#   ./dev/scripts/lint-pr-strict.sh -b origin/develop        # Compare to develop
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -99,7 +100,7 @@ log_header()  { echo -e "\n${BOLD}${BLUE}=== $* ===${NC}\n"; }
 # ==============================================================================
 
 show_help() {
-    sed -n '3,18p' "$0" | sed 's/^# //' | sed 's/^#//'
+    sed -n '3,22p' "$0" | sed 's/^# //' | sed 's/^#//'
     exit 0
 }
 
@@ -126,6 +127,56 @@ get_changed_files() {
     echo "$files"
 }
 
+get_all_files() {
+    local path_filter="$1"
+
+    local files
+    files=$(find "$REPO_ROOT/$path_filter" -name '*.ts' -o -name '*.tsx' | sed "s|^$REPO_ROOT/||")
+
+    # Apply exclusion patterns
+    for pattern in "${EXCLUDED_PATTERNS[@]}"; do
+        files=$(echo "$files" | grep -v "$pattern" || true)
+    done
+
+    # Exclude node_modules, dist, generated
+    files=$(echo "$files" | grep -v 'node_modules/' | grep -v '/dist/' | grep -v '/generated/' | grep -v '/.next/' || true)
+
+    echo "$files"
+}
+
+# Detect the right tsconfig for a single file
+detect_tsconfig_for_file() {
+    local file="$1"
+
+    if [[ "$file" == apps/web/* ]]; then
+        echo "apps/web/tsconfig.json"
+    elif [[ "$file" == internal-packages/ai/* ]]; then
+        echo "internal-packages/ai/tsconfig.json"
+    elif [[ "$file" == internal-packages/db/* ]]; then
+        echo "internal-packages/db/tsconfig.json"
+    elif [[ "$file" == internal-packages/domain/* ]]; then
+        echo "internal-packages/domain/tsconfig.json"
+    elif [[ "$file" == internal-packages/jobs/* ]]; then
+        echo "internal-packages/jobs/tsconfig.json"
+    elif [[ "$file" == apps/mcp-server/* ]]; then
+        echo "apps/mcp-server/tsconfig.json"
+    else
+        echo "tsconfig.json"
+    fi
+}
+
+# Group files by their tsconfig
+group_files_by_tsconfig() {
+    local files="$1"
+    # Output: tsconfig\tfile lines, sorted by tsconfig
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        local tsconfig
+        tsconfig=$(detect_tsconfig_for_file "$file")
+        echo -e "${tsconfig}\t${file}"
+    done <<< "$files" | sort -t$'\t' -k1,1
+}
+
 run_eslint() {
     local files="$1"
 
@@ -145,26 +196,59 @@ run_eslint() {
         rule_args+=("--rule=$rule")
     done
 
-    # Convert newline-separated files to array
-    local file_array=()
-    while IFS= read -r file; do
-        [[ -n "$file" ]] && file_array+=("$file")
-    done <<< "$files"
-
-    # Run eslint from repo root
     cd "$REPO_ROOT"
 
-    npx eslint \
-        --config apps/web/config/eslint/.eslintrc.json \
-        "${rule_args[@]}" \
-        "${file_array[@]}"
+    # Group files by tsconfig and run eslint per group
+    local grouped
+    grouped=$(group_files_by_tsconfig "$files")
+
+    local current_tsconfig=""
+    local current_files=()
+    local had_errors=false
+
+    while IFS=$'\t' read -r tsconfig file; do
+        if [[ "$tsconfig" != "$current_tsconfig" ]]; then
+            # Run previous group if any
+            if [[ ${#current_files[@]} -gt 0 ]]; then
+                log_info "Using tsconfig: $current_tsconfig (${#current_files[@]} files)"
+                if ! npx eslint \
+                    --config apps/web/config/eslint/.eslintrc.json \
+                    --parser-options="project:$current_tsconfig" \
+                    "${rule_args[@]}" \
+                    "${current_files[@]}"; then
+                    had_errors=true
+                fi
+                echo ""
+            fi
+            current_tsconfig="$tsconfig"
+            current_files=()
+        fi
+        current_files+=("$file")
+    done <<< "$grouped"
+
+    # Run last group
+    if [[ ${#current_files[@]} -gt 0 ]]; then
+        log_info "Using tsconfig: $current_tsconfig (${#current_files[@]} files)"
+        if ! npx eslint \
+            --config apps/web/config/eslint/.eslintrc.json \
+            --parser-options="project:$current_tsconfig" \
+            "${rule_args[@]}" \
+            "${current_files[@]}"; then
+            had_errors=true
+        fi
+    fi
+
+    if $had_errors; then
+        return 1
+    fi
+    return 0
 }
 
 list_files() {
     local files="$1"
 
     if [[ -z "$files" ]]; then
-        log_warning "No TypeScript files changed in this scope."
+        log_warning "No TypeScript files in this scope."
         return 0
     fi
 
@@ -183,6 +267,7 @@ main() {
     local base_branch="$DEFAULT_BASE_BRANCH"
     local path_filter=""
     local list_only=false
+    local check_all=false
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -198,6 +283,10 @@ main() {
                 list_only=true
                 shift
                 ;;
+            -a|--all)
+                check_all=true
+                shift
+                ;;
             -*)
                 log_error "Unknown option: $1"
                 show_help
@@ -209,19 +298,31 @@ main() {
         esac
     done
 
-    log_header "Strict PR Lint Check"
-
-    log_info "Base branch: $base_branch"
-    if [[ -n "$path_filter" ]]; then
-        log_info "Path filter: $path_filter"
+    if $check_all; then
+        log_header "Strict Lint Check (all files)"
+        if [[ -z "$path_filter" ]]; then
+            log_error "Path is required with --all flag"
+            exit 1
+        fi
+        log_info "Scope: $path_filter"
     else
-        log_info "Path filter: (all changed files, excluding meta-evals)"
+        log_header "Strict PR Lint Check"
+        log_info "Base branch: $base_branch"
+        if [[ -n "$path_filter" ]]; then
+            log_info "Path filter: $path_filter"
+        else
+            log_info "Path filter: (all changed files, excluding meta-evals)"
+        fi
     fi
     echo ""
 
-    # Get changed files
+    # Get files
     local files
-    files=$(get_changed_files "$base_branch" "$path_filter")
+    if $check_all; then
+        files=$(get_all_files "$path_filter")
+    else
+        files=$(get_changed_files "$base_branch" "$path_filter")
+    fi
 
     if $list_only; then
         list_files "$files"

--- a/internal-packages/db/prisma/migrations/20260302000000_add_batch_completion_and_notification_fields/migration.sql
+++ b/internal-packages/db/prisma/migrations/20260302000000_add_batch_completion_and_notification_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "AgentEvalBatch" ADD COLUMN "completedAt" TIMESTAMP(3),
+ADD COLUMN "notifyOnComplete" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "notifiedAt" TIMESTAMP(3);

--- a/internal-packages/db/prisma/migrations/20260315115731_add_document_notification_fields/migration.sql
+++ b/internal-packages/db/prisma/migrations/20260315115731_add_document_notification_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."Document" ADD COLUMN     "notifiedAt" TIMESTAMP(3),
+ADD COLUMN     "notifyOnComplete" BOOLEAN NOT NULL DEFAULT false;

--- a/internal-packages/db/prisma/schema.prisma
+++ b/internal-packages/db/prisma/schema.prisma
@@ -238,6 +238,9 @@ model AgentEvalBatch {
   trackingId           String?
   description          String?
   expiresAt            DateTime?
+  completedAt          DateTime?
+  notifyOnComplete     Boolean    @default(false)
+  notifiedAt           DateTime?
   isEphemeral          Boolean    @default(false)
   ephemeralAgent       Agent?     @relation("EphemeralAgent")
   agent                Agent      @relation(fields: [agentId], references: [id], onDelete: Cascade, onUpdate: Cascade)

--- a/internal-packages/db/prisma/schema.prisma
+++ b/internal-packages/db/prisma/schema.prisma
@@ -70,18 +70,20 @@ model VerificationToken {
 }
 
 model Document {
-  id               String            @id
-  publishedDate    DateTime
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
-  submittedById    String
-  ephemeralBatchId String?
-  isPrivate        Boolean           @default(true)
-  ephemeralBatch   AgentEvalBatch?   @relation("EphemeralDocuments", fields: [ephemeralBatchId], references: [id], onDelete: Cascade)
-  submittedBy      User              @relation(fields: [submittedById], references: [id], onDelete: Cascade)
-  versions         DocumentVersion[]
-  evaluations      Evaluation[]
-  series           Series[]
+  id                String            @id
+  publishedDate     DateTime
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  submittedById     String
+  ephemeralBatchId  String?
+  isPrivate         Boolean           @default(true)
+  notifyOnComplete  Boolean           @default(false)
+  notifiedAt        DateTime?
+  ephemeralBatch    AgentEvalBatch?   @relation("EphemeralDocuments", fields: [ephemeralBatchId], references: [id], onDelete: Cascade)
+  submittedBy       User              @relation(fields: [submittedById], references: [id], onDelete: Cascade)
+  versions          DocumentVersion[]
+  evaluations       Evaluation[]
+  series            Series[]
 
   @@index([ephemeralBatchId])
   @@index([isPrivate])

--- a/internal-packages/db/src/index.ts
+++ b/internal-packages/db/src/index.ts
@@ -9,6 +9,7 @@ export { Prisma, type PrismaClient } from './client';
 export * from './repositories/DocumentRepository';
 export * from './repositories/EvaluationRepository';
 export * from './repositories/JobRepository';
+export * from './repositories/NotificationRepository';
 export * from './repositories/MetaEvaluationRepository';
 
 // Browser-safe exports (types and enums only)

--- a/internal-packages/db/src/repositories/DocumentRepository.ts
+++ b/internal-packages/db/src/repositories/DocumentRepository.ts
@@ -93,6 +93,7 @@ export interface DocumentRepositoryInterface {
   create(data: CreateDocumentData): Promise<DocumentEntity>;
   updateContent(id: string, content: string, title: string, markdownPrepend?: string): Promise<void>;
   updateMetadata(id: string, data: { intendedAgentIds?: string[] }): Promise<void>;
+  setNotifyOnComplete(id: string, notifyOnComplete: boolean): Promise<void>;
   delete(id: string): Promise<boolean>;
   checkOwnership(docId: string, userId: string): Promise<boolean>;
   search(query: string, limit?: number, requestingUserId?: string): Promise<any[]>;
@@ -450,6 +451,16 @@ export class DocumentRepository implements DocumentRepositoryInterface {
         });
       }
     }
+  }
+
+  /**
+   * Set the notification preference for a document.
+   */
+  async setNotifyOnComplete(id: string, notifyOnComplete: boolean): Promise<void> {
+    await this.prisma.document.update({
+      where: { id },
+      data: { notifyOnComplete },
+    });
   }
 
   /**

--- a/internal-packages/db/src/repositories/DocumentRepository.ts
+++ b/internal-packages/db/src/repositories/DocumentRepository.ts
@@ -44,6 +44,7 @@ export interface DocumentWithEvaluations {
   };
   importUrl: string | null;
   ephemeralBatchId: string | null;
+  notifyOnComplete: boolean;
   reviews: any[];
   intendedAgents: string[];
 }
@@ -633,6 +634,7 @@ export class DocumentRepository implements DocumentRepositoryInterface {
       } : undefined,
       importUrl: latestVersion.importUrl,
       ephemeralBatchId: doc.ephemeralBatchId,
+      notifyOnComplete: doc.notifyOnComplete,
       reviews,
       intendedAgents: latestVersion.intendedAgents || []
     };

--- a/internal-packages/db/src/repositories/DocumentRepository.ts
+++ b/internal-packages/db/src/repositories/DocumentRepository.ts
@@ -62,6 +62,7 @@ export interface CreateDocumentData {
   markdownPrepend?: string;
   isPrivate?: boolean;
   submitterNotes?: string;
+  notifyOnComplete?: boolean;
 }
 
 export interface UpdateDocumentData {
@@ -376,6 +377,7 @@ export class DocumentRepository implements DocumentRepositoryInterface {
         submittedById: data.submittedById,
         ephemeralBatchId: data.ephemeralBatchId,
         isPrivate: data.isPrivate || false,
+        notifyOnComplete: data.notifyOnComplete || false,
         versions: {
           create: {
             title: data.title,

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -110,6 +110,23 @@ export interface BatchNotificationData {
   completedCount: number;
   failedCount: number;
   totalCount: number;
+  requestedDocumentIds: string[];
+}
+
+export interface DocumentCompletionResult {
+  id: string;
+  notifiedAt: Date;
+}
+
+export interface DocumentNotificationData {
+  id: string;
+  title: string;
+  notifyOnComplete: boolean;
+  notifiedAt: Date | null;
+  userEmail: string | null;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
 }
 
 export interface StaleJobCriteria {
@@ -135,6 +152,9 @@ export interface JobRepositoryInterface {
   tryMarkBatchCompleted(batchId: string): Promise<BatchCompletionResult | null>;
   getBatchForNotification(batchId: string): Promise<BatchNotificationData | null>;
   markBatchNotified(batchId: string): Promise<void>;
+  getDocumentIdForJob(jobId: string): Promise<string | null>;
+  tryMarkDocumentCompleted(documentId: string): Promise<DocumentCompletionResult | null>;
+  getDocumentForNotification(documentId: string): Promise<DocumentNotificationData | null>;
 }
 
 export class JobRepository implements JobRepositoryInterface {
@@ -384,6 +404,7 @@ export class JobRepository implements JobRepositoryInterface {
       completedCount,
       failedCount,
       totalCount: batch.jobs.length,
+      requestedDocumentIds: batch.requestedDocumentIds,
     };
   }
 
@@ -397,6 +418,90 @@ export class JobRepository implements JobRepositoryInterface {
       WHERE id = ${batchId}
         AND "notifiedAt" IS NULL
     `;
+  }
+
+  /**
+   * Get the documentId associated with a job (via its evaluation).
+   */
+  async getDocumentIdForJob(jobId: string): Promise<string | null> {
+    const result = await this.prisma.job.findUnique({
+      where: { id: jobId },
+      select: { evaluation: { select: { documentId: true } } },
+    });
+    return result?.evaluation?.documentId ?? null;
+  }
+
+  /**
+   * Atomically mark a document as notification-sent if all jobs are terminal.
+   * Returns the document ID if this call "won" the completion, null otherwise.
+   *
+   * Supports re-evaluations: if new jobs were created after the last notification,
+   * the notification cycle resets automatically (no external reset needed).
+   */
+  async tryMarkDocumentCompleted(documentId: string): Promise<DocumentCompletionResult | null> {
+    const result = await this.prisma.$queryRaw<DocumentCompletionResult[]>`
+      UPDATE "Document"
+      SET "notifiedAt" = NOW()
+      WHERE id = ${documentId}
+        AND "notifyOnComplete" = true
+        AND NOT EXISTS (
+          SELECT 1 FROM "Job" j
+          JOIN "Evaluation" e ON e.id = j."evaluationId"
+          WHERE e."documentId" = ${documentId}
+            AND j.status IN ('PENDING', 'RUNNING')
+        )
+        AND (
+          "notifiedAt" IS NULL
+          OR EXISTS (
+            SELECT 1 FROM "Job" j
+            JOIN "Evaluation" e ON e.id = j."evaluationId"
+            WHERE e."documentId" = ${documentId}
+              AND j."createdAt" > "Document"."notifiedAt"
+          )
+        )
+      RETURNING id, "notifiedAt"
+    `;
+
+    return result.length > 0 ? result[0] : null;
+  }
+
+  /**
+   * Fetch document data needed for sending completion notifications.
+   */
+  async getDocumentForNotification(documentId: string): Promise<DocumentNotificationData | null> {
+    const doc = await this.prisma.document.findUnique({
+      where: { id: documentId },
+      include: {
+        submittedBy: { select: { email: true } },
+        versions: {
+          orderBy: { version: 'desc' as const },
+          take: 1,
+          select: { title: true },
+        },
+        evaluations: {
+          include: {
+            jobs: { select: { status: true } },
+          },
+        },
+      },
+    });
+
+    if (!doc) return null;
+
+    const allJobs = doc.evaluations.flatMap(e => e.jobs);
+    const completedCount = allJobs.filter(j => j.status === 'COMPLETED').length;
+    const failedCount = allJobs.filter(j => j.status === 'FAILED').length;
+
+    return {
+      id: doc.id,
+      title: doc.versions[0]?.title || 'Untitled Document',
+      notifyOnComplete: doc.notifyOnComplete,
+      notifiedAt: doc.notifiedAt,
+      userEmail: doc.submittedBy.email,
+      completedCount,
+      failedCount,
+      totalCount: allJobs.length,
+    };
   }
 
   private toJobWithRelations(job: any): JobWithRelations {

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -155,6 +155,7 @@ export interface JobRepositoryInterface {
   getDocumentIdForJob(jobId: string): Promise<string | null>;
   tryMarkDocumentCompleted(documentId: string): Promise<DocumentCompletionResult | null>;
   getDocumentForNotification(documentId: string): Promise<DocumentNotificationData | null>;
+  resetDocumentNotification(documentId: string): Promise<void>;
 }
 
 export class JobRepository implements JobRepositoryInterface {
@@ -502,6 +503,17 @@ export class JobRepository implements JobRepositoryInterface {
       failedCount,
       totalCount: allJobs.length,
     };
+  }
+
+  /**
+   * Reset notifiedAt so a future job transition can re-trigger notification.
+   * Used when email delivery fails after completion was already detected.
+   */
+  async resetDocumentNotification(documentId: string): Promise<void> {
+    await this.prisma.document.update({
+      where: { id: documentId },
+      data: { notifiedAt: null },
+    });
   }
 
   private toJobWithRelations(job: any): JobWithRelations {

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -391,8 +391,8 @@ export class JobRepository implements JobRepositoryInterface {
 
     if (!batch) return null;
 
-    const completedCount = batch.jobs.filter(j => j.status === 'COMPLETED').length;
-    const failedCount = batch.jobs.filter(j => j.status === 'FAILED').length;
+    const completedCount = batch.jobs.filter(j => j.status === JobStatus.COMPLETED).length;
+    const failedCount = batch.jobs.filter(j => j.status === JobStatus.FAILED).length;
 
     return {
       id: batch.id,
@@ -490,8 +490,8 @@ export class JobRepository implements JobRepositoryInterface {
     if (!doc) return null;
 
     const allJobs = doc.evaluations.flatMap(e => e.jobs);
-    const completedCount = allJobs.filter(j => j.status === 'COMPLETED').length;
-    const failedCount = allJobs.filter(j => j.status === 'FAILED').length;
+    const completedCount = allJobs.filter(j => j.status === JobStatus.COMPLETED).length;
+    const failedCount = allJobs.filter(j => j.status === JobStatus.FAILED).length;
 
     return {
       id: doc.id,

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -94,6 +94,24 @@ export interface UpdateJobStatusData {
   attempts?: number;
 }
 
+export interface BatchCompletionResult {
+  id: string;
+  completedAt: Date;
+}
+
+export interface BatchNotificationData {
+  id: string;
+  name: string | null;
+  agentId: string;
+  agentName: string;
+  notifyOnComplete: boolean;
+  notifiedAt: Date | null;
+  userEmail: string | null;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
+}
+
 export interface StaleJobCriteria {
   status: JobStatus;
   thresholdMs: number;
@@ -114,6 +132,9 @@ export interface JobRepositoryInterface {
   findJobsForCostUpdate(limit: number, maxAgeHours?: number): Promise<JobEntity[]>;
   updateCost(id: string, cost: number): Promise<JobEntity>;
   findStaleJobs(criteria: StaleJobCriteria[]): Promise<StaleJobResult[]>;
+  tryMarkBatchCompleted(batchId: string): Promise<BatchCompletionResult | null>;
+  getBatchForNotification(batchId: string): Promise<BatchNotificationData | null>;
+  markBatchNotified(batchId: string): Promise<void>;
 }
 
 export class JobRepository implements JobRepositoryInterface {
@@ -308,6 +329,76 @@ export class JobRepository implements JobRepositoryInterface {
   /**
    * Convert database record with relations to job with relations
    */
+  /**
+   * Atomically mark a batch as completed if all jobs are in terminal states.
+   * Returns the batch ID if this call "won" the completion, null otherwise.
+   * The `completedAt IS NULL` condition prevents duplicate completions.
+   */
+  async tryMarkBatchCompleted(batchId: string): Promise<BatchCompletionResult | null> {
+    const result = await this.prisma.$queryRaw<BatchCompletionResult[]>`
+      UPDATE "AgentEvalBatch"
+      SET "completedAt" = NOW()
+      WHERE id = ${batchId}
+        AND "completedAt" IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "Job"
+          WHERE "agentEvalBatchId" = ${batchId}
+            AND status IN ('PENDING', 'RUNNING')
+        )
+      RETURNING id, "completedAt"
+    `;
+
+    return result.length > 0 ? result[0] : null;
+  }
+
+  /**
+   * Fetch batch data needed for sending completion notifications.
+   */
+  async getBatchForNotification(batchId: string): Promise<BatchNotificationData | null> {
+    const batch = await this.prisma.agentEvalBatch.findUnique({
+      where: { id: batchId },
+      include: {
+        user: { select: { email: true } },
+        agent: {
+          include: {
+            versions: { orderBy: { version: 'desc' as const }, take: 1, select: { name: true } },
+          },
+        },
+        jobs: { select: { status: true } },
+      },
+    });
+
+    if (!batch) return null;
+
+    const completedCount = batch.jobs.filter(j => j.status === 'COMPLETED').length;
+    const failedCount = batch.jobs.filter(j => j.status === 'FAILED').length;
+
+    return {
+      id: batch.id,
+      name: batch.name,
+      agentId: batch.agentId,
+      agentName: batch.agent.versions[0]?.name || 'Unknown Agent',
+      notifyOnComplete: batch.notifyOnComplete,
+      notifiedAt: batch.notifiedAt,
+      userEmail: batch.user.email,
+      completedCount,
+      failedCount,
+      totalCount: batch.jobs.length,
+    };
+  }
+
+  /**
+   * Atomically mark a batch as notified (prevents duplicate emails).
+   */
+  async markBatchNotified(batchId: string): Promise<void> {
+    await this.prisma.$queryRaw`
+      UPDATE "AgentEvalBatch"
+      SET "notifiedAt" = NOW()
+      WHERE id = ${batchId}
+        AND "notifiedAt" IS NULL
+    `;
+  }
+
   private toJobWithRelations(job: any): JobWithRelations {
     return {
       ...this.toDomainEntity(job),

--- a/internal-packages/db/src/repositories/JobRepository.ts
+++ b/internal-packages/db/src/repositories/JobRepository.ts
@@ -99,34 +99,9 @@ export interface BatchCompletionResult {
   completedAt: Date;
 }
 
-export interface BatchNotificationData {
-  id: string;
-  name: string | null;
-  agentId: string;
-  agentName: string;
-  notifyOnComplete: boolean;
-  notifiedAt: Date | null;
-  userEmail: string | null;
-  completedCount: number;
-  failedCount: number;
-  totalCount: number;
-  requestedDocumentIds: string[];
-}
-
 export interface DocumentCompletionResult {
   id: string;
   notifiedAt: Date;
-}
-
-export interface DocumentNotificationData {
-  id: string;
-  title: string;
-  notifyOnComplete: boolean;
-  notifiedAt: Date | null;
-  userEmail: string | null;
-  completedCount: number;
-  failedCount: number;
-  totalCount: number;
 }
 
 export interface StaleJobCriteria {
@@ -150,12 +125,8 @@ export interface JobRepositoryInterface {
   updateCost(id: string, cost: number): Promise<JobEntity>;
   findStaleJobs(criteria: StaleJobCriteria[]): Promise<StaleJobResult[]>;
   tryMarkBatchCompleted(batchId: string): Promise<BatchCompletionResult | null>;
-  getBatchForNotification(batchId: string): Promise<BatchNotificationData | null>;
-  markBatchNotified(batchId: string): Promise<void>;
   getDocumentIdForJob(jobId: string): Promise<string | null>;
   tryMarkDocumentCompleted(documentId: string): Promise<DocumentCompletionResult | null>;
-  getDocumentForNotification(documentId: string): Promise<DocumentNotificationData | null>;
-  resetDocumentNotification(documentId: string): Promise<void>;
 }
 
 export class JobRepository implements JobRepositoryInterface {
@@ -373,55 +344,6 @@ export class JobRepository implements JobRepositoryInterface {
   }
 
   /**
-   * Fetch batch data needed for sending completion notifications.
-   */
-  async getBatchForNotification(batchId: string): Promise<BatchNotificationData | null> {
-    const batch = await this.prisma.agentEvalBatch.findUnique({
-      where: { id: batchId },
-      include: {
-        user: { select: { email: true } },
-        agent: {
-          include: {
-            versions: { orderBy: { version: 'desc' as const }, take: 1, select: { name: true } },
-          },
-        },
-        jobs: { select: { status: true } },
-      },
-    });
-
-    if (!batch) return null;
-
-    const completedCount = batch.jobs.filter(j => j.status === JobStatus.COMPLETED).length;
-    const failedCount = batch.jobs.filter(j => j.status === JobStatus.FAILED).length;
-
-    return {
-      id: batch.id,
-      name: batch.name,
-      agentId: batch.agentId,
-      agentName: batch.agent.versions[0]?.name || 'Unknown Agent',
-      notifyOnComplete: batch.notifyOnComplete,
-      notifiedAt: batch.notifiedAt,
-      userEmail: batch.user.email,
-      completedCount,
-      failedCount,
-      totalCount: batch.jobs.length,
-      requestedDocumentIds: batch.requestedDocumentIds,
-    };
-  }
-
-  /**
-   * Atomically mark a batch as notified (prevents duplicate emails).
-   */
-  async markBatchNotified(batchId: string): Promise<void> {
-    await this.prisma.$queryRaw`
-      UPDATE "AgentEvalBatch"
-      SET "notifiedAt" = NOW()
-      WHERE id = ${batchId}
-        AND "notifiedAt" IS NULL
-    `;
-  }
-
-  /**
    * Get the documentId associated with a job (via its evaluation).
    */
   async getDocumentIdForJob(jobId: string): Promise<string | null> {
@@ -464,56 +386,6 @@ export class JobRepository implements JobRepositoryInterface {
     `;
 
     return result.length > 0 ? result[0] : null;
-  }
-
-  /**
-   * Fetch document data needed for sending completion notifications.
-   */
-  async getDocumentForNotification(documentId: string): Promise<DocumentNotificationData | null> {
-    const doc = await this.prisma.document.findUnique({
-      where: { id: documentId },
-      include: {
-        submittedBy: { select: { email: true } },
-        versions: {
-          orderBy: { version: 'desc' as const },
-          take: 1,
-          select: { title: true },
-        },
-        evaluations: {
-          include: {
-            jobs: { select: { status: true } },
-          },
-        },
-      },
-    });
-
-    if (!doc) return null;
-
-    const allJobs = doc.evaluations.flatMap(e => e.jobs);
-    const completedCount = allJobs.filter(j => j.status === JobStatus.COMPLETED).length;
-    const failedCount = allJobs.filter(j => j.status === JobStatus.FAILED).length;
-
-    return {
-      id: doc.id,
-      title: doc.versions[0]?.title || 'Untitled Document',
-      notifyOnComplete: doc.notifyOnComplete,
-      notifiedAt: doc.notifiedAt,
-      userEmail: doc.submittedBy.email,
-      completedCount,
-      failedCount,
-      totalCount: allJobs.length,
-    };
-  }
-
-  /**
-   * Reset notifiedAt so a future job transition can re-trigger notification.
-   * Used when email delivery fails after completion was already detected.
-   */
-  async resetDocumentNotification(documentId: string): Promise<void> {
-    await this.prisma.document.update({
-      where: { id: documentId },
-      data: { notifiedAt: null },
-    });
   }
 
   private toJobWithRelations(job: any): JobWithRelations {

--- a/internal-packages/db/src/repositories/NotificationRepository.ts
+++ b/internal-packages/db/src/repositories/NotificationRepository.ts
@@ -1,0 +1,143 @@
+/**
+ * Notification Repository
+ *
+ * Data access for notification-related queries.
+ * Separated from JobRepository to keep persistence concerns distinct
+ * from notification/workflow concerns.
+ */
+
+import { prisma as defaultPrisma } from '../client';
+import { JobStatus } from '../types';
+import type { PrismaClient } from '../client';
+
+export interface BatchNotificationData {
+  id: string;
+  name: string | null;
+  agentId: string;
+  agentName: string;
+  notifyOnComplete: boolean;
+  notifiedAt: Date | null;
+  userEmail: string | null;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
+  requestedDocumentIds: string[];
+}
+
+export interface DocumentNotificationData {
+  id: string;
+  title: string;
+  notifyOnComplete: boolean;
+  notifiedAt: Date | null;
+  userEmail: string | null;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
+}
+
+export class NotificationRepository {
+  private prisma: typeof defaultPrisma;
+
+  constructor(prismaClient?: typeof defaultPrisma) {
+    this.prisma = prismaClient || defaultPrisma;
+  }
+
+  /**
+   * Fetch batch data needed for sending completion notifications.
+   */
+  async getBatchForNotification(batchId: string): Promise<BatchNotificationData | null> {
+    const batch = await this.prisma.agentEvalBatch.findUnique({
+      where: { id: batchId },
+      include: {
+        user: { select: { email: true } },
+        agent: {
+          include: {
+            versions: { orderBy: { version: 'desc' as const }, take: 1, select: { name: true } },
+          },
+        },
+        jobs: { select: { status: true } },
+      },
+    });
+
+    if (!batch) return null;
+
+    const completedCount = batch.jobs.filter(j => j.status === JobStatus.COMPLETED).length;
+    const failedCount = batch.jobs.filter(j => j.status === JobStatus.FAILED).length;
+
+    return {
+      id: batch.id,
+      name: batch.name,
+      agentId: batch.agentId,
+      agentName: batch.agent.versions[0]?.name || 'Unknown Agent',
+      notifyOnComplete: batch.notifyOnComplete,
+      notifiedAt: batch.notifiedAt,
+      userEmail: batch.user.email,
+      completedCount,
+      failedCount,
+      totalCount: batch.jobs.length,
+      requestedDocumentIds: batch.requestedDocumentIds,
+    };
+  }
+
+  /**
+   * Atomically mark a batch as notified (prevents duplicate emails).
+   */
+  async markBatchNotified(batchId: string): Promise<void> {
+    await this.prisma.$queryRaw`
+      UPDATE "AgentEvalBatch"
+      SET "notifiedAt" = NOW()
+      WHERE id = ${batchId}
+        AND "notifiedAt" IS NULL
+    `;
+  }
+
+  /**
+   * Fetch document data needed for sending completion notifications.
+   */
+  async getDocumentForNotification(documentId: string): Promise<DocumentNotificationData | null> {
+    const doc = await this.prisma.document.findUnique({
+      where: { id: documentId },
+      include: {
+        submittedBy: { select: { email: true } },
+        versions: {
+          orderBy: { version: 'desc' as const },
+          take: 1,
+          select: { title: true },
+        },
+        evaluations: {
+          include: {
+            jobs: { select: { status: true } },
+          },
+        },
+      },
+    });
+
+    if (!doc) return null;
+
+    const allJobs = doc.evaluations.flatMap(e => e.jobs);
+    const completedCount = allJobs.filter(j => j.status === JobStatus.COMPLETED).length;
+    const failedCount = allJobs.filter(j => j.status === JobStatus.FAILED).length;
+
+    return {
+      id: doc.id,
+      title: doc.versions[0]?.title || 'Untitled Document',
+      notifyOnComplete: doc.notifyOnComplete,
+      notifiedAt: doc.notifiedAt,
+      userEmail: doc.submittedBy.email,
+      completedCount,
+      failedCount,
+      totalCount: allJobs.length,
+    };
+  }
+
+  /**
+   * Reset notifiedAt so a future job transition can re-trigger notification.
+   * Used when email delivery fails after completion was already detected.
+   */
+  async resetDocumentNotification(documentId: string): Promise<void> {
+    await this.prisma.document.update({
+      where: { id: documentId },
+      data: { notifiedAt: null },
+    });
+  }
+}

--- a/internal-packages/domain/src/entities/document/Document.entity.ts
+++ b/internal-packages/domain/src/entities/document/Document.entity.ts
@@ -165,6 +165,7 @@ export interface DocumentWithEvaluations {
   };
   importUrl?: string;
   ephemeralBatchId?: string;
+  notifyOnComplete?: boolean;
   reviews: any[]; // Will be properly typed with Evaluation entity
   intendedAgents: string[];
 }

--- a/internal-packages/domain/src/services/DocumentService.ts
+++ b/internal-packages/domain/src/services/DocumentService.ts
@@ -17,7 +17,8 @@ import { generateMarkdownPrepend } from '../utils/documentMetadata';
 import type { DocumentValidator } from '../validators/DocumentValidator';
 import type { EvaluationService } from './EvaluationService';
 import type { Logger } from '../core/logger';
-import { 
+
+import {
   DocumentEntity,
   DocumentWithEvaluations,
   CreateDocumentData,
@@ -64,7 +65,8 @@ export class DocumentService {
   async createDocument(
     userId: string,
     data: CreateDocumentRequest,
-    agentIds?: string[]
+    agentIds?: string[],
+    notifyOnComplete?: boolean
   ): Promise<Result<DocumentEntity, AppError>> {
     try {
       // Generate title if not provided
@@ -104,7 +106,8 @@ export class DocumentService {
         ephemeralBatchId: data.ephemeralBatchId,
         markdownPrepend,
         isPrivate: data.isPrivate || false,
-        submitterNotes: data.submitterNotes
+        submitterNotes: data.submitterNotes,
+        notifyOnComplete: notifyOnComplete && agentIds && agentIds.length > 0 ? true : false,
       } as RepositoryCreateDocumentData;
 
       const repoDocument = await this.docRepo.create(createData);
@@ -115,7 +118,7 @@ export class DocumentService {
         const evaluationResult = await this.evaluationService.createEvaluationsForDocument({
           documentId: document.id,
           agentIds,
-          userId
+          userId,
         });
 
         if (evaluationResult.isError()) {

--- a/internal-packages/domain/src/services/DocumentService.ts
+++ b/internal-packages/domain/src/services/DocumentService.ts
@@ -107,7 +107,7 @@ export class DocumentService {
         markdownPrepend,
         isPrivate: data.isPrivate || false,
         submitterNotes: data.submitterNotes,
-        notifyOnComplete: notifyOnComplete && agentIds && agentIds.length > 0 ? true : false,
+        notifyOnComplete: notifyOnComplete ?? false,
       } as RepositoryCreateDocumentData;
 
       const repoDocument = await this.docRepo.create(createData);

--- a/internal-packages/domain/src/services/DocumentService.ts
+++ b/internal-packages/domain/src/services/DocumentService.ts
@@ -391,6 +391,33 @@ export class DocumentService {
   }
 
   /**
+   * Set the notification preference for a document.
+   * Only the document owner can change this setting.
+   */
+  async setNotifyOnComplete(
+    docId: string,
+    userId: string,
+    notifyOnComplete: boolean
+  ): Promise<Result<void, AppError>> {
+    try {
+      const isOwner = await this.docRepo.checkOwnership(docId, userId);
+      if (!isOwner) {
+        return Result.fail(
+          new AuthorizationError('You do not have permission to update this document')
+        );
+      }
+
+      await this.docRepo.setNotifyOnComplete(docId, notifyOnComplete);
+      return Result.ok(undefined);
+    } catch (error) {
+      this.logger.error('Error updating notification preference', { error, docId, userId });
+      return Result.fail(
+        new AppError('Failed to update notification preference', 'NOTIFICATION_UPDATE_ERROR', 500, error)
+      );
+    }
+  }
+
+  /**
    * Get document statistics
    */
   async getStatistics(): Promise<Result<any, AppError>> {

--- a/internal-packages/jobs/package.json
+++ b/internal-packages/jobs/package.json
@@ -29,7 +29,8 @@
     "@roast/db": "workspace:*",
     "@roast/domain": "workspace:*",
     "dotenv": "^17.2.0",
-    "pg-boss": "^12.2.0"
+    "pg-boss": "^12.2.0",
+    "resend": "^6.9.3"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",

--- a/internal-packages/jobs/src/cli/process-pgboss-worker.ts
+++ b/internal-packages/jobs/src/cli/process-pgboss-worker.ts
@@ -33,6 +33,7 @@ import { updateJobCostsFromHelicone } from '../scheduled-tasks/helicone-poller';
 import { JobReconciliationService } from '../scheduled-tasks/job-reconciliation';
 import { EmailService } from '../core/EmailService';
 import { BatchNotificationHandler } from '../core/BatchNotificationHandler';
+import { DocumentNotificationHandler } from '../core/DocumentNotificationHandler';
 
 interface JobWithAgentVersions {
   evaluation: {
@@ -61,14 +62,18 @@ class PgBossWorker {
     this.jobOrchestrator = new JobOrchestrator(this.jobRepository, logger, this.jobService);
     this.jobReconciliationService = new JobReconciliationService(this.jobRepository, this.pgBossService, logger);
 
-    // Wire up batch completion email notifications
+    // Wire up email notifications for batch and document completions
     const emailService = new EmailService(logger);
     if (emailService.isConfigured) {
-      const notificationHandler = new BatchNotificationHandler(this.jobRepository, emailService, logger);
-      this.jobService.setBatchCompletionHandler(notificationHandler);
-      logger.info('Email notifications enabled for batch completions');
+      const batchHandler = new BatchNotificationHandler(this.jobRepository, emailService, logger);
+      this.jobService.setBatchCompletionHandler(batchHandler);
+
+      const documentHandler = new DocumentNotificationHandler(this.jobRepository, emailService, logger);
+      this.jobService.setDocumentCompletionHandler(documentHandler);
+
+      logger.info('Email notifications enabled for batch and document completions');
     } else {
-      logger.info('Email not configured, batch completion notifications disabled');
+      logger.info('Email not configured, completion notifications disabled');
     }
   }
 

--- a/internal-packages/jobs/src/cli/process-pgboss-worker.ts
+++ b/internal-packages/jobs/src/cli/process-pgboss-worker.ts
@@ -18,7 +18,7 @@ loadWebAppEnvironment(workspaceRoot);
 process.env.AI_LOG_LEVEL ??= 'warn';
 
 import { config } from '@roast/domain';
-import { JobRepository } from '@roast/db';
+import { JobRepository, NotificationRepository } from '@roast/db';
 import { JobOrchestrator } from '../core/JobOrchestrator';
 import { JobService } from '../core/JobService';
 import { PgBossService } from '../core/PgBossService';
@@ -65,10 +65,12 @@ class PgBossWorker {
     // Wire up email notifications for batch and document completions
     const emailService = new EmailService(logger);
     if (emailService.isConfigured) {
-      const batchHandler = new BatchNotificationHandler(this.jobRepository, emailService, logger);
+      const notificationRepository = new NotificationRepository();
+
+      const batchHandler = new BatchNotificationHandler(notificationRepository, emailService, logger);
       this.jobService.setBatchCompletionHandler(batchHandler);
 
-      const documentHandler = new DocumentNotificationHandler(this.jobRepository, emailService, logger);
+      const documentHandler = new DocumentNotificationHandler(notificationRepository, emailService, logger);
       this.jobService.setDocumentCompletionHandler(documentHandler);
 
       logger.info('Email notifications enabled for batch and document completions');

--- a/internal-packages/jobs/src/cli/process-pgboss-worker.ts
+++ b/internal-packages/jobs/src/cli/process-pgboss-worker.ts
@@ -60,7 +60,7 @@ class PgBossWorker {
     this.jobRepository = new JobRepository();
     this.jobService = new JobService(this.jobRepository, logger, this.pgBossService);
     this.jobOrchestrator = new JobOrchestrator(this.jobRepository, logger, this.jobService);
-    this.jobReconciliationService = new JobReconciliationService(this.jobRepository, this.pgBossService, logger);
+    this.jobReconciliationService = new JobReconciliationService(this.jobRepository, this.pgBossService, logger, this.jobService);
 
     // Wire up email notifications for batch and document completions
     const emailService = new EmailService(logger);

--- a/internal-packages/jobs/src/cli/process-pgboss-worker.ts
+++ b/internal-packages/jobs/src/cli/process-pgboss-worker.ts
@@ -31,6 +31,8 @@ import { isRetryableError } from '../errors/retryableErrors';
 import { getAgentTimeout } from '../config/agentTimeouts';
 import { updateJobCostsFromHelicone } from '../scheduled-tasks/helicone-poller';
 import { JobReconciliationService } from '../scheduled-tasks/job-reconciliation';
+import { EmailService } from '../core/EmailService';
+import { BatchNotificationHandler } from '../core/BatchNotificationHandler';
 
 interface JobWithAgentVersions {
   evaluation: {
@@ -58,6 +60,16 @@ class PgBossWorker {
     this.jobService = new JobService(this.jobRepository, logger, this.pgBossService);
     this.jobOrchestrator = new JobOrchestrator(this.jobRepository, logger, this.jobService);
     this.jobReconciliationService = new JobReconciliationService(this.jobRepository, this.pgBossService, logger);
+
+    // Wire up batch completion email notifications
+    const emailService = new EmailService(logger);
+    if (emailService.isConfigured) {
+      const notificationHandler = new BatchNotificationHandler(this.jobRepository, emailService, logger);
+      this.jobService.setBatchCompletionHandler(notificationHandler);
+      logger.info('Email notifications enabled for batch completions');
+    } else {
+      logger.info('Email not configured, batch completion notifications disabled');
+    }
   }
 
   public async start() {

--- a/internal-packages/jobs/src/core/BatchNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/BatchNotificationHandler.ts
@@ -5,23 +5,21 @@
  * notifications when batches complete. Used by the worker process.
  */
 
-import type { JobRepository } from '@roast/db';
+import type { NotificationRepository } from '@roast/db';
 import type { BatchCompletionHandler } from './JobService';
 import type { EmailService } from './EmailService';
 import type { Logger } from '../types';
 
 export class BatchNotificationHandler implements BatchCompletionHandler {
   constructor(
-    private jobRepository: JobRepository,
+    private notificationRepository: NotificationRepository,
     private emailService: EmailService,
     private logger: Logger
   ) {}
 
   async onBatchCompleted(batchId: string): Promise<void> {
-    if (!this.emailService.isConfigured) return;
-
     try {
-      const batch = await this.jobRepository.getBatchForNotification(batchId);
+      const batch = await this.notificationRepository.getBatchForNotification(batchId);
       if (!batch) return;
       if (!batch.notifyOnComplete) return;
       if (batch.notifiedAt) return;
@@ -31,7 +29,8 @@ export class BatchNotificationHandler implements BatchCompletionHandler {
         return;
       }
 
-      const emailSent = await this.emailService.sendBatchCompletionEmail({
+      const emailSent = await this.emailService.sendCompletionEmail({
+        type: 'batch',
         recipientEmail: batch.userEmail,
         batchName: batch.name,
         agentName: batch.agentName,
@@ -40,11 +39,10 @@ export class BatchNotificationHandler implements BatchCompletionHandler {
         failedCount: batch.failedCount,
         totalCount: batch.totalCount,
         batchId: batch.id,
-        documentId: batch.requestedDocumentIds.length === 1 ? batch.requestedDocumentIds[0] : undefined,
       });
 
       if (emailSent) {
-        await this.jobRepository.markBatchNotified(batchId);
+        await this.notificationRepository.markBatchNotified(batchId);
       }
     } catch (error) {
       // Email notification failure must not affect job processing

--- a/internal-packages/jobs/src/core/BatchNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/BatchNotificationHandler.ts
@@ -1,0 +1,53 @@
+/**
+ * BatchNotificationHandler
+ *
+ * Implements the BatchCompletionHandler interface to send email
+ * notifications when batches complete. Used by the worker process.
+ */
+
+import type { JobRepository } from '@roast/db';
+import type { BatchCompletionHandler } from './JobService';
+import type { EmailService } from './EmailService';
+import type { Logger } from '../types';
+
+export class BatchNotificationHandler implements BatchCompletionHandler {
+  constructor(
+    private jobRepository: JobRepository,
+    private emailService: EmailService,
+    private logger: Logger
+  ) {}
+
+  async onBatchCompleted(batchId: string): Promise<void> {
+    if (!this.emailService.isConfigured) return;
+
+    try {
+      const batch = await this.jobRepository.getBatchForNotification(batchId);
+      if (!batch) return;
+      if (!batch.notifyOnComplete) return;
+      if (batch.notifiedAt) return;
+
+      if (!batch.userEmail) {
+        this.logger.warn(`Batch ${batchId} notification requested but user has no email`);
+        return;
+      }
+
+      const emailSent = await this.emailService.sendBatchCompletionEmail({
+        recipientEmail: batch.userEmail,
+        batchName: batch.name,
+        agentName: batch.agentName,
+        agentId: batch.agentId,
+        completedCount: batch.completedCount,
+        failedCount: batch.failedCount,
+        totalCount: batch.totalCount,
+        batchId: batch.id,
+      });
+
+      if (emailSent) {
+        await this.jobRepository.markBatchNotified(batchId);
+      }
+    } catch (error) {
+      // Email notification failure must not affect job processing
+      this.logger.error(`Failed to send notification for batch ${batchId}:`, error);
+    }
+  }
+}

--- a/internal-packages/jobs/src/core/BatchNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/BatchNotificationHandler.ts
@@ -40,6 +40,7 @@ export class BatchNotificationHandler implements BatchCompletionHandler {
         failedCount: batch.failedCount,
         totalCount: batch.totalCount,
         batchId: batch.id,
+        documentId: batch.requestedDocumentIds.length === 1 ? batch.requestedDocumentIds[0] : undefined,
       });
 
       if (emailSent) {

--- a/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
@@ -6,23 +6,21 @@
  * Used by the worker process.
  */
 
-import type { JobRepository } from '@roast/db';
+import type { NotificationRepository } from '@roast/db';
 import type { DocumentCompletionHandler } from './JobService';
 import type { EmailService } from './EmailService';
 import type { Logger } from '../types';
 
 export class DocumentNotificationHandler implements DocumentCompletionHandler {
   constructor(
-    private jobRepository: JobRepository,
+    private notificationRepository: NotificationRepository,
     private emailService: EmailService,
     private logger: Logger
   ) {}
 
   async onDocumentCompleted(documentId: string): Promise<void> {
-    if (!this.emailService.isConfigured) return;
-
     try {
-      const doc = await this.jobRepository.getDocumentForNotification(documentId);
+      const doc = await this.notificationRepository.getDocumentForNotification(documentId);
       if (!doc) return;
       if (!doc.notifyOnComplete) return;
 
@@ -31,23 +29,18 @@ export class DocumentNotificationHandler implements DocumentCompletionHandler {
         return;
       }
 
-      const emailSent = await this.emailService.sendBatchCompletionEmail({
+      const emailSent = await this.emailService.sendCompletionEmail({
+        type: 'document',
         recipientEmail: doc.userEmail,
-        batchName: null,
-        agentName: '',
-        agentId: '',
+        documentId,
         completedCount: doc.completedCount,
         failedCount: doc.failedCount,
         totalCount: doc.totalCount,
-        batchId: documentId,
-        documentId,
       });
 
-      if (emailSent) {
-        this.logger.info(`Document completion email sent for ${documentId}`);
-      } else {
+      if (!emailSent) {
         // Reset notifiedAt so a future job transition can re-trigger notification
-        await this.jobRepository.resetDocumentNotification(documentId);
+        await this.notificationRepository.resetDocumentNotification(documentId);
         this.logger.warn(`Document ${documentId} email failed, reset notifiedAt for retry`);
       }
     } catch (error) {

--- a/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
@@ -1,0 +1,54 @@
+/**
+ * DocumentNotificationHandler
+ *
+ * Implements the DocumentCompletionHandler interface to send email
+ * notifications when all evaluations for a document complete.
+ * Used by the worker process.
+ */
+
+import type { JobRepository } from '@roast/db';
+import type { DocumentCompletionHandler } from './JobService';
+import type { EmailService } from './EmailService';
+import type { Logger } from '../types';
+
+export class DocumentNotificationHandler implements DocumentCompletionHandler {
+  constructor(
+    private jobRepository: JobRepository,
+    private emailService: EmailService,
+    private logger: Logger
+  ) {}
+
+  async onDocumentCompleted(documentId: string): Promise<void> {
+    if (!this.emailService.isConfigured) return;
+
+    try {
+      const doc = await this.jobRepository.getDocumentForNotification(documentId);
+      if (!doc) return;
+      if (!doc.notifyOnComplete) return;
+      if (doc.notifiedAt) return;
+
+      if (!doc.userEmail) {
+        this.logger.warn(`Document ${documentId} notification requested but user has no email`);
+        return;
+      }
+
+      await this.emailService.sendBatchCompletionEmail({
+        recipientEmail: doc.userEmail,
+        batchName: null,
+        agentName: '',
+        agentId: '',
+        completedCount: doc.completedCount,
+        failedCount: doc.failedCount,
+        totalCount: doc.totalCount,
+        batchId: documentId,
+        documentId,
+      });
+
+      // notifiedAt is already set atomically by tryMarkDocumentCompleted
+      this.logger.info(`Document completion email sent for ${documentId} to ${doc.userEmail}`);
+    } catch (error) {
+      // Email notification failure must not affect job processing
+      this.logger.error(`Failed to send notification for document ${documentId}:`, error);
+    }
+  }
+}

--- a/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
@@ -44,7 +44,7 @@ export class DocumentNotificationHandler implements DocumentCompletionHandler {
       });
 
       // notifiedAt is already set atomically by tryMarkDocumentCompleted
-      this.logger.info(`Document completion email sent for ${documentId} to ${doc.userEmail}`);
+      this.logger.info(`Document completion email sent for ${documentId}`);
     } catch (error) {
       // Email notification failure must not affect job processing
       this.logger.error(`Failed to send notification for document ${documentId}:`, error);

--- a/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
@@ -25,7 +25,6 @@ export class DocumentNotificationHandler implements DocumentCompletionHandler {
       const doc = await this.jobRepository.getDocumentForNotification(documentId);
       if (!doc) return;
       if (!doc.notifyOnComplete) return;
-      if (doc.notifiedAt) return;
 
       if (!doc.userEmail) {
         this.logger.warn(`Document ${documentId} notification requested but user has no email`);

--- a/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
+++ b/internal-packages/jobs/src/core/DocumentNotificationHandler.ts
@@ -31,7 +31,7 @@ export class DocumentNotificationHandler implements DocumentCompletionHandler {
         return;
       }
 
-      await this.emailService.sendBatchCompletionEmail({
+      const emailSent = await this.emailService.sendBatchCompletionEmail({
         recipientEmail: doc.userEmail,
         batchName: null,
         agentName: '',
@@ -43,8 +43,13 @@ export class DocumentNotificationHandler implements DocumentCompletionHandler {
         documentId,
       });
 
-      // notifiedAt is already set atomically by tryMarkDocumentCompleted
-      this.logger.info(`Document completion email sent for ${documentId}`);
+      if (emailSent) {
+        this.logger.info(`Document completion email sent for ${documentId}`);
+      } else {
+        // Reset notifiedAt so a future job transition can re-trigger notification
+        await this.jobRepository.resetDocumentNotification(documentId);
+        this.logger.warn(`Document ${documentId} email failed, reset notifiedAt for retry`);
+      }
     } catch (error) {
       // Email notification failure must not affect job processing
       this.logger.error(`Failed to send notification for document ${documentId}:`, error);

--- a/internal-packages/jobs/src/core/EmailService.ts
+++ b/internal-packages/jobs/src/core/EmailService.ts
@@ -2,7 +2,7 @@
  * EmailService
  *
  * Sends transactional emails via Resend.
- * Used by the worker to notify users when batches complete.
+ * Used by the worker to notify users when evaluations complete.
  */
 
 import { Resend } from 'resend';
@@ -10,17 +10,27 @@ import { config } from '@roast/domain';
 import { escapeXml } from '@roast/ai';
 import type { Logger } from '../types';
 
-export interface BatchCompletionEmailData {
+interface CompletionCounts {
   recipientEmail: string;
-  batchName: string | null;
-  agentName: string;
-  agentId: string;
   completedCount: number;
   failedCount: number;
   totalCount: number;
-  batchId: string;
-  documentId?: string;
 }
+
+export interface BatchCompletionEmailData extends CompletionCounts {
+  type: 'batch';
+  batchId: string;
+  batchName: string | null;
+  agentName: string;
+  agentId: string;
+}
+
+export interface DocumentCompletionEmailData extends CompletionCounts {
+  type: 'document';
+  documentId: string;
+}
+
+export type CompletionEmailData = BatchCompletionEmailData | DocumentCompletionEmailData;
 
 export class EmailService {
   private resend: Resend | null = null;
@@ -36,33 +46,14 @@ export class EmailService {
     return this.resend !== null && !!config.auth.emailFrom;
   }
 
-  async sendBatchCompletionEmail(data: BatchCompletionEmailData): Promise<boolean> {
+  async sendCompletionEmail(data: CompletionEmailData): Promise<boolean> {
     if (!this.isConfigured || !this.resend) {
-      this.logger.warn('Email not configured, skipping batch completion notification');
+      this.logger.warn('Email not configured, skipping completion notification');
       return false;
     }
 
     const baseUrl = config.auth.nextAuthUrl || 'https://roastmypost.com';
-    const isDocumentNotification = !!data.documentId;
-    const resultsUrl = isDocumentNotification
-      ? `${baseUrl}/docs/${data.documentId}/reader`
-      : `${baseUrl}/evaluators/${data.agentId}`;
-    const batchLabel = data.batchName || `Batch ${data.batchId.slice(0, 8)}`;
-    const successRate = data.totalCount > 0
-      ? Math.round((data.completedCount / data.totalCount) * 100)
-      : 0;
-
-    const subject = isDocumentNotification
-      ? `Your document evaluations are complete (${data.completedCount}/${data.totalCount} succeeded)`
-      : `Batch complete: ${batchLabel} (${successRate}% success)`;
-
-    const heading = isDocumentNotification
-      ? 'Document Evaluations Complete'
-      : 'Batch Evaluation Complete';
-
-    const description = isDocumentNotification
-      ? `Your document evaluations have finished. ${data.completedCount} of ${data.totalCount} evaluations completed successfully.`
-      : `Your evaluation batch <strong>${escapeXml(batchLabel)}</strong> for agent <strong>${escapeXml(data.agentName)}</strong> has finished.`;
+    const { subject, heading, description, resultsUrl, logId } = this.buildEmailContent(data, baseUrl);
 
     const html = `
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
@@ -102,15 +93,40 @@ export class EmailService {
       });
 
       if (sendError) {
-        this.logger.error(`Failed to send completion email for ${data.batchId}:`, sendError);
+        this.logger.error(`Failed to send completion email for ${logId}:`, sendError);
         return false;
       }
 
-      this.logger.info(`Completion email sent for ${data.batchId}`);
+      this.logger.info(`Completion email sent for ${logId}`);
       return true;
     } catch (error) {
-      this.logger.error(`Failed to send completion email for ${data.batchId}:`, error);
+      this.logger.error(`Failed to send completion email for ${logId}:`, error);
       return false;
     }
+  }
+
+  private buildEmailContent(data: CompletionEmailData, baseUrl: string) {
+    if (data.type === 'document') {
+      return {
+        subject: `Your document evaluations are complete (${data.completedCount}/${data.totalCount} succeeded)`,
+        heading: 'Document Evaluations Complete',
+        description: `Your document evaluations have finished. ${data.completedCount} of ${data.totalCount} evaluations completed successfully.`,
+        resultsUrl: `${baseUrl}/docs/${data.documentId}/reader`,
+        logId: `document ${data.documentId}`,
+      };
+    }
+
+    const batchLabel = data.batchName || `Batch ${data.batchId.slice(0, 8)}`;
+    const successRate = data.totalCount > 0
+      ? Math.round((data.completedCount / data.totalCount) * 100)
+      : 0;
+
+    return {
+      subject: `Batch complete: ${batchLabel} (${successRate}% success)`,
+      heading: 'Batch Evaluation Complete',
+      description: `Your evaluation batch <strong>${escapeXml(batchLabel)}</strong> for agent <strong>${escapeXml(data.agentName)}</strong> has finished.`,
+      resultsUrl: `${baseUrl}/evaluators/${data.agentId}`,
+      logId: `batch ${data.batchId}`,
+    };
   }
 }

--- a/internal-packages/jobs/src/core/EmailService.ts
+++ b/internal-packages/jobs/src/core/EmailService.ts
@@ -18,6 +18,7 @@ export interface BatchCompletionEmailData {
   failedCount: number;
   totalCount: number;
   batchId: string;
+  documentId?: string;
 }
 
 export class EmailService {
@@ -41,19 +42,32 @@ export class EmailService {
     }
 
     const baseUrl = config.auth.nextAuthUrl || 'https://roastmypost.com';
-    const batchUrl = `${baseUrl}/evaluators/${data.agentId}`;
+    const isDocumentNotification = !!data.documentId;
+    const resultsUrl = isDocumentNotification
+      ? `${baseUrl}/docs/${data.documentId}/reader`
+      : `${baseUrl}/evaluators/${data.agentId}`;
     const batchLabel = data.batchName || `Batch ${data.batchId.slice(0, 8)}`;
     const successRate = data.totalCount > 0
       ? Math.round((data.completedCount / data.totalCount) * 100)
       : 0;
 
-    const subject = `Batch complete: ${batchLabel} (${successRate}% success)`;
+    const subject = isDocumentNotification
+      ? `Your document evaluations are complete (${data.completedCount}/${data.totalCount} succeeded)`
+      : `Batch complete: ${batchLabel} (${successRate}% success)`;
+
+    const heading = isDocumentNotification
+      ? 'Document Evaluations Complete'
+      : 'Batch Evaluation Complete';
+
+    const description = isDocumentNotification
+      ? `Your document evaluations have finished. ${data.completedCount} of ${data.totalCount} evaluations completed successfully.`
+      : `Your evaluation batch <strong>${escapeHtml(batchLabel)}</strong> for agent <strong>${escapeHtml(data.agentName)}</strong> has finished.`;
 
     const html = `
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-        <h2 style="color: #1a1a1a; margin-bottom: 16px;">Batch Evaluation Complete</h2>
+        <h2 style="color: #1a1a1a; margin-bottom: 16px;">${heading}</h2>
         <p style="color: #4a4a4a; margin-bottom: 24px;">
-          Your evaluation batch <strong>${escapeHtml(batchLabel)}</strong> for agent <strong>${escapeHtml(data.agentName)}</strong> has finished.
+          ${description}
         </p>
         <table style="border-collapse: collapse; width: 100%; margin-bottom: 24px;">
           <tr>
@@ -68,16 +82,12 @@ export class EmailService {
             <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Total</td>
             <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.totalCount}</td>
           </tr>
-          <tr>
-            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Success Rate</td>
-            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${successRate}%</td>
-          </tr>
         </table>
-        <a href="${batchUrl}" style="display: inline-block; background: #2563eb; color: #ffffff; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 500;">
+        <a href="${resultsUrl}" style="display: inline-block; background: #2563eb; color: #ffffff; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 500;">
           View Results
         </a>
         <p style="color: #9a9a9a; font-size: 12px; margin-top: 32px;">
-          You received this email because you checked "Email me when this batch completes" when creating the batch.
+          You received this email because you opted in to evaluation completion notifications.
         </p>
       </div>
     `;

--- a/internal-packages/jobs/src/core/EmailService.ts
+++ b/internal-packages/jobs/src/core/EmailService.ts
@@ -93,17 +93,22 @@ export class EmailService {
     `;
 
     try {
-      await this.resend.emails.send({
+      const { error: sendError } = await this.resend.emails.send({
         from: config.auth.emailFrom!,
         to: data.recipientEmail,
         subject,
         html,
       });
 
-      this.logger.info(`Batch completion email sent for batch ${data.batchId} to ${data.recipientEmail}`);
+      if (sendError) {
+        this.logger.error(`Failed to send completion email for ${data.batchId}:`, sendError);
+        return false;
+      }
+
+      this.logger.info(`Completion email sent for ${data.batchId}`);
       return true;
     } catch (error) {
-      this.logger.error(`Failed to send batch completion email for batch ${data.batchId}:`, error);
+      this.logger.error(`Failed to send completion email for ${data.batchId}:`, error);
       return false;
     }
   }

--- a/internal-packages/jobs/src/core/EmailService.ts
+++ b/internal-packages/jobs/src/core/EmailService.ts
@@ -1,0 +1,108 @@
+/**
+ * EmailService
+ *
+ * Sends transactional emails via Resend.
+ * Used by the worker to notify users when batches complete.
+ */
+
+import { Resend } from 'resend';
+import { config } from '@roast/domain';
+import type { Logger } from '../types';
+
+export interface BatchCompletionEmailData {
+  recipientEmail: string;
+  batchName: string | null;
+  agentName: string;
+  agentId: string;
+  completedCount: number;
+  failedCount: number;
+  totalCount: number;
+  batchId: string;
+}
+
+export class EmailService {
+  private resend: Resend | null = null;
+
+  constructor(private logger: Logger) {
+    const apiKey = config.auth.resendKey;
+    if (apiKey) {
+      this.resend = new Resend(apiKey);
+    }
+  }
+
+  get isConfigured(): boolean {
+    return this.resend !== null && !!config.auth.emailFrom;
+  }
+
+  async sendBatchCompletionEmail(data: BatchCompletionEmailData): Promise<boolean> {
+    if (!this.isConfigured || !this.resend) {
+      this.logger.warn('Email not configured, skipping batch completion notification');
+      return false;
+    }
+
+    const baseUrl = config.auth.nextAuthUrl || 'https://roastmypost.com';
+    const batchUrl = `${baseUrl}/evaluators/${data.agentId}`;
+    const batchLabel = data.batchName || `Batch ${data.batchId.slice(0, 8)}`;
+    const successRate = data.totalCount > 0
+      ? Math.round((data.completedCount / data.totalCount) * 100)
+      : 0;
+
+    const subject = `Batch complete: ${batchLabel} (${successRate}% success)`;
+
+    const html = `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #1a1a1a; margin-bottom: 16px;">Batch Evaluation Complete</h2>
+        <p style="color: #4a4a4a; margin-bottom: 24px;">
+          Your evaluation batch <strong>${escapeHtml(batchLabel)}</strong> for agent <strong>${escapeHtml(data.agentName)}</strong> has finished.
+        </p>
+        <table style="border-collapse: collapse; width: 100%; margin-bottom: 24px;">
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Completed</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.completedCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Failed</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.failedCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Total</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${data.totalCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0; background: #f9f9f9; font-weight: 600;">Success Rate</td>
+            <td style="padding: 8px 16px; border: 1px solid #e0e0e0;">${successRate}%</td>
+          </tr>
+        </table>
+        <a href="${batchUrl}" style="display: inline-block; background: #2563eb; color: #ffffff; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 500;">
+          View Results
+        </a>
+        <p style="color: #9a9a9a; font-size: 12px; margin-top: 32px;">
+          You received this email because you checked "Email me when this batch completes" when creating the batch.
+        </p>
+      </div>
+    `;
+
+    try {
+      await this.resend.emails.send({
+        from: config.auth.emailFrom!,
+        to: data.recipientEmail,
+        subject,
+        html,
+      });
+
+      this.logger.info(`Batch completion email sent for batch ${data.batchId} to ${data.recipientEmail}`);
+      return true;
+    } catch (error) {
+      this.logger.error(`Failed to send batch completion email for batch ${data.batchId}:`, error);
+      return false;
+    }
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/internal-packages/jobs/src/core/EmailService.ts
+++ b/internal-packages/jobs/src/core/EmailService.ts
@@ -7,6 +7,7 @@
 
 import { Resend } from 'resend';
 import { config } from '@roast/domain';
+import { escapeXml } from '@roast/ai';
 import type { Logger } from '../types';
 
 export interface BatchCompletionEmailData {
@@ -61,7 +62,7 @@ export class EmailService {
 
     const description = isDocumentNotification
       ? `Your document evaluations have finished. ${data.completedCount} of ${data.totalCount} evaluations completed successfully.`
-      : `Your evaluation batch <strong>${escapeHtml(batchLabel)}</strong> for agent <strong>${escapeHtml(data.agentName)}</strong> has finished.`;
+      : `Your evaluation batch <strong>${escapeXml(batchLabel)}</strong> for agent <strong>${escapeXml(data.agentName)}</strong> has finished.`;
 
     const html = `
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
@@ -112,12 +113,4 @@ export class EmailService {
       return false;
     }
   }
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -126,8 +126,10 @@ export class JobService {
 
     // Update database to mark as cancelled
     const cancelledJob = await this.markAsCancelled(jobId);
-    await this.checkBatchCompletion(cancelledJob);
-    await this.checkDocumentCompletion(cancelledJob);
+    await Promise.all([
+      this.checkBatchCompletion(cancelledJob),
+      this.checkDocumentCompletion(cancelledJob),
+    ]);
     return cancelledJob;
   }
 
@@ -174,8 +176,10 @@ export class JobService {
       durationInSeconds: data.durationInSeconds,
       logs: data.logs,
     });
-    await this.checkBatchCompletion(completedJob);
-    await this.checkDocumentCompletion(completedJob);
+    await Promise.all([
+      this.checkBatchCompletion(completedJob),
+      this.checkDocumentCompletion(completedJob),
+    ]);
     return completedJob;
   }
 
@@ -188,8 +192,10 @@ export class JobService {
       error: error instanceof Error ? error.message : String(error),
       completedAt: new Date(),
     });
-    await this.checkBatchCompletion(failedJob);
-    await this.checkDocumentCompletion(failedJob);
+    await Promise.all([
+      this.checkBatchCompletion(failedJob),
+      this.checkDocumentCompletion(failedJob),
+    ]);
     return failedJob;
   }
 

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -219,16 +219,16 @@ export class JobService {
    * Uses an atomic UPDATE to ensure only one worker detects completion.
    */
   private async checkDocumentCompletion(job: JobEntity): Promise<void> {
-    if (!this.documentCompletionHandler) return;
-
     try {
       const documentId = await this.jobRepository.getDocumentIdForJob(job.id);
       if (!documentId) return;
 
       const result = await this.jobRepository.tryMarkDocumentCompleted(documentId);
       if (result) {
-        this.logger.info(`Document ${result.id} evaluations completed, triggering notification`);
-        await this.documentCompletionHandler.onDocumentCompleted(result.id);
+        this.logger.info(`Document ${result.id} evaluations completed`);
+        if (this.documentCompletionHandler) {
+          await this.documentCompletionHandler.onDocumentCompleted(result.id);
+        }
       }
     } catch (error) {
       // Document completion tracking is non-critical — don't fail the job

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -13,12 +13,26 @@ import { PgBossService } from './PgBossService';
 import { DOCUMENT_EVALUATION_JOB } from '../types/jobTypes';
 import type { Logger } from '../types';
 
+export interface BatchCompletionHandler {
+  onBatchCompleted(batchId: string): Promise<void>;
+}
+
 export class JobService {
+  private batchCompletionHandler?: BatchCompletionHandler;
+
   constructor(
     private jobRepository: JobRepository,
     private logger: Logger,
     private pgBossService: PgBossService
   ) {}
+
+  /**
+   * Set an optional handler that is called when a batch completes.
+   * Used by the worker to trigger email notifications.
+   */
+  setBatchCompletionHandler(handler: BatchCompletionHandler): void {
+    this.batchCompletionHandler = handler;
+  }
 
   async initialize() {
     await this.pgBossService.initialize();
@@ -98,7 +112,9 @@ export class JobService {
     }
 
     // Update database to mark as cancelled
-    return this.markAsCancelled(jobId);
+    const cancelledJob = await this.markAsCancelled(jobId);
+    await this.checkBatchCompletion(cancelledJob);
+    return cancelledJob;
   }
 
   /**
@@ -137,24 +153,48 @@ export class JobService {
       logs: string;
     }
   ) {
-    return this.jobRepository.updateStatus(jobId, {
+    const completedJob = await this.jobRepository.updateStatus(jobId, {
       status: JobStatus.COMPLETED,
       completedAt: new Date(),
       llmThinking: data.llmThinking,
       durationInSeconds: data.durationInSeconds,
       logs: data.logs,
     });
+    await this.checkBatchCompletion(completedJob);
+    return completedJob;
   }
 
   /**
    * Mark a job as failed
    */
   async markAsFailed(jobId: string, error: unknown): Promise<JobEntity> {
-    return this.jobRepository.updateStatus(jobId, {
+    const failedJob = await this.jobRepository.updateStatus(jobId, {
       status: JobStatus.FAILED,
       error: error instanceof Error ? error.message : String(error),
       completedAt: new Date(),
     });
+    await this.checkBatchCompletion(failedJob);
+    return failedJob;
   }
 
+  /**
+   * Check if a job's batch is now complete (all jobs in terminal states).
+   * Uses an atomic UPDATE to ensure only one worker detects completion.
+   */
+  private async checkBatchCompletion(job: JobEntity): Promise<void> {
+    if (!job.agentEvalBatchId) return;
+
+    try {
+      const result = await this.jobRepository.tryMarkBatchCompleted(job.agentEvalBatchId);
+      if (result) {
+        this.logger.info(`Batch ${result.id} completed at ${result.completedAt.toISOString()}`);
+        if (this.batchCompletionHandler) {
+          await this.batchCompletionHandler.onBatchCompleted(result.id);
+        }
+      }
+    } catch (error) {
+      // Batch completion tracking is non-critical — don't fail the job
+      this.logger.error(`Failed to check batch completion for batch ${job.agentEvalBatchId}:`, error);
+    }
+  }
 }

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -17,8 +17,13 @@ export interface BatchCompletionHandler {
   onBatchCompleted(batchId: string): Promise<void>;
 }
 
+export interface DocumentCompletionHandler {
+  onDocumentCompleted(documentId: string): Promise<void>;
+}
+
 export class JobService {
   private batchCompletionHandler?: BatchCompletionHandler;
+  private documentCompletionHandler?: DocumentCompletionHandler;
 
   constructor(
     private jobRepository: JobRepository,
@@ -32,6 +37,14 @@ export class JobService {
    */
   setBatchCompletionHandler(handler: BatchCompletionHandler): void {
     this.batchCompletionHandler = handler;
+  }
+
+  /**
+   * Set an optional handler that is called when all jobs for a document complete.
+   * Used by the worker to trigger email notifications.
+   */
+  setDocumentCompletionHandler(handler: DocumentCompletionHandler): void {
+    this.documentCompletionHandler = handler;
   }
 
   async initialize() {
@@ -114,6 +127,7 @@ export class JobService {
     // Update database to mark as cancelled
     const cancelledJob = await this.markAsCancelled(jobId);
     await this.checkBatchCompletion(cancelledJob);
+    await this.checkDocumentCompletion(cancelledJob);
     return cancelledJob;
   }
 
@@ -161,6 +175,7 @@ export class JobService {
       logs: data.logs,
     });
     await this.checkBatchCompletion(completedJob);
+    await this.checkDocumentCompletion(completedJob);
     return completedJob;
   }
 
@@ -174,6 +189,7 @@ export class JobService {
       completedAt: new Date(),
     });
     await this.checkBatchCompletion(failedJob);
+    await this.checkDocumentCompletion(failedJob);
     return failedJob;
   }
 
@@ -195,6 +211,28 @@ export class JobService {
     } catch (error) {
       // Batch completion tracking is non-critical — don't fail the job
       this.logger.error(`Failed to check batch completion for batch ${job.agentEvalBatchId}:`, error);
+    }
+  }
+
+  /**
+   * Check if all jobs for a document are now complete.
+   * Uses an atomic UPDATE to ensure only one worker detects completion.
+   */
+  private async checkDocumentCompletion(job: JobEntity): Promise<void> {
+    if (!this.documentCompletionHandler) return;
+
+    try {
+      const documentId = await this.jobRepository.getDocumentIdForJob(job.id);
+      if (!documentId) return;
+
+      const result = await this.jobRepository.tryMarkDocumentCompleted(documentId);
+      if (result) {
+        this.logger.info(`Document ${result.id} evaluations completed, triggering notification`);
+        await this.documentCompletionHandler.onDocumentCompleted(result.id);
+      }
+    } catch (error) {
+      // Document completion tracking is non-critical — don't fail the job
+      this.logger.error(`Failed to check document completion for job ${job.id}:`, error);
     }
   }
 }

--- a/internal-packages/jobs/src/core/JobService.ts
+++ b/internal-packages/jobs/src/core/JobService.ts
@@ -219,6 +219,11 @@ export class JobService {
    * Uses an atomic UPDATE to ensure only one worker detects completion.
    */
   private async checkDocumentCompletion(job: JobEntity): Promise<void> {
+    // Only detect completion when a handler is attached (worker process).
+    // Without this guard, web-side cancellations would consume the completion
+    // edge and set notifiedAt without being able to send an email.
+    if (!this.documentCompletionHandler) return;
+
     try {
       const documentId = await this.jobRepository.getDocumentIdForJob(job.id);
       if (!documentId) return;
@@ -226,9 +231,7 @@ export class JobService {
       const result = await this.jobRepository.tryMarkDocumentCompleted(documentId);
       if (result) {
         this.logger.info(`Document ${result.id} evaluations completed`);
-        if (this.documentCompletionHandler) {
-          await this.documentCompletionHandler.onDocumentCompleted(result.id);
-        }
+        await this.documentCompletionHandler.onDocumentCompleted(result.id);
       }
     } catch (error) {
       // Document completion tracking is non-critical — don't fail the job

--- a/internal-packages/jobs/src/index.ts
+++ b/internal-packages/jobs/src/index.ts
@@ -5,7 +5,9 @@
 // Core services
 export { JobOrchestrator, type JobOrchestratorInterface } from './core/JobOrchestrator';
 export { PgBossService } from './core/PgBossService';
-export { JobService } from './core/JobService';
+export { JobService, type BatchCompletionHandler } from './core/JobService';
+export { EmailService, type BatchCompletionEmailData } from './core/EmailService';
+export { BatchNotificationHandler } from './core/BatchNotificationHandler';
 
 // Job types
 export {

--- a/internal-packages/jobs/src/index.ts
+++ b/internal-packages/jobs/src/index.ts
@@ -5,9 +5,10 @@
 // Core services
 export { JobOrchestrator, type JobOrchestratorInterface } from './core/JobOrchestrator';
 export { PgBossService } from './core/PgBossService';
-export { JobService, type BatchCompletionHandler } from './core/JobService';
+export { JobService, type BatchCompletionHandler, type DocumentCompletionHandler } from './core/JobService';
 export { EmailService, type BatchCompletionEmailData } from './core/EmailService';
 export { BatchNotificationHandler } from './core/BatchNotificationHandler';
+export { DocumentNotificationHandler } from './core/DocumentNotificationHandler';
 
 // Job types
 export {

--- a/internal-packages/jobs/src/index.ts
+++ b/internal-packages/jobs/src/index.ts
@@ -6,7 +6,7 @@
 export { JobOrchestrator, type JobOrchestratorInterface } from './core/JobOrchestrator';
 export { PgBossService } from './core/PgBossService';
 export { JobService, type BatchCompletionHandler, type DocumentCompletionHandler } from './core/JobService';
-export { EmailService, type BatchCompletionEmailData } from './core/EmailService';
+export { EmailService, type CompletionEmailData, type BatchCompletionEmailData, type DocumentCompletionEmailData } from './core/EmailService';
 export { BatchNotificationHandler } from './core/BatchNotificationHandler';
 export { DocumentNotificationHandler } from './core/DocumentNotificationHandler';
 

--- a/internal-packages/jobs/src/scheduled-tasks/job-reconciliation.ts
+++ b/internal-packages/jobs/src/scheduled-tasks/job-reconciliation.ts
@@ -6,6 +6,7 @@
 
 import { JobStatus, JobRepository } from '@roast/db';
 import { PgBossService } from '../core/PgBossService';
+import { JobService } from '../core/JobService';
 import { DOCUMENT_EVALUATION_JOB } from '../types/jobTypes';
 import type { Logger } from '../types';
 import { PgBoss } from 'pg-boss';
@@ -29,7 +30,8 @@ export class JobReconciliationService {
   constructor(
     private readonly jobRepository: JobRepository,
     private readonly pgBossService: PgBossService,
-    private readonly logger: Logger
+    private readonly logger: Logger,
+    private readonly jobService?: JobService
   ) {}
 
   async reconcileStaleJobs(): Promise<void> {
@@ -90,12 +92,18 @@ export class JobReconciliationService {
   ): Promise<void> {
     const staleMinutes = Math.round((Date.now() - job.updatedAt.getTime()) / 60000);
     const reason = job.pgBossJobId ? 'pg-boss job not active' : 'no pg-boss job ID';
+    const error = `Job stuck in ${job.status} for ${staleMinutes}min - ${reason}`;
 
-    await this.jobRepository.updateStatus(job.id, {
-      status: JobStatus.FAILED,
-      error: `Job stuck in ${job.status} for ${staleMinutes}min - ${reason}`,
-      completedAt: new Date(),
-    });
+    if (this.jobService) {
+      // Use JobService to trigger batch/document completion checks
+      await this.jobService.markAsFailed(job.id, error);
+    } else {
+      await this.jobRepository.updateStatus(job.id, {
+        status: JobStatus.FAILED,
+        error,
+        completedAt: new Date(),
+      });
+    }
 
     this.logger.info(`[Reconciliation] Marked ${job.status} job ${job.id} as FAILED (${reason})`);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,6 +520,9 @@ importers:
       pg-boss:
         specifier: ^12.2.0
         version: 12.2.0
+      resend:
+        specifier: ^6.9.3
+        version: 6.9.3
     devDependencies:
       '@types/node':
         specifier: ^20.11.5
@@ -2688,6 +2691,9 @@ packages:
   '@sinclair/typebox@0.34.38':
     resolution: {integrity: sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -4139,6 +4145,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
@@ -5405,6 +5414,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.3:
+    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -5754,6 +5766,15 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  resend@6.9.3:
+    resolution: {integrity: sha512-GRXjH9XZBJA+daH7bBVDuTShr22iWCxXA8P7t495G4dM/RC+d+3gHBK/6bz9K6Vpcq11zRQKmD+B+jECwQlyGQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -5993,6 +6014,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -6120,6 +6144,9 @@ packages:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  svix@1.84.1:
+    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -6484,6 +6511,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -9431,6 +9462,8 @@ snapshots:
   '@sinclair/typebox@0.34.38':
     optional: true
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -9976,7 +10009,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11193,6 +11226,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.0.6: {}
 
@@ -12742,6 +12777,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.3: {}
+
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -13081,6 +13118,11 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  resend@6.9.3:
+    dependencies:
+      postal-mime: 2.7.3
+      svix: 1.84.1
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -13397,6 +13439,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.1: {}
 
   std-env@3.9.0: {}
@@ -13554,6 +13601,11 @@ snapshots:
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
+
+  svix@1.84.1:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -13963,6 +14015,8 @@ snapshots:
       react: 19.2.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
## Summary
Built on top of #402 which added batch completion tracking and email notifications for the TestTab path. This PR adds the document submission path:

- Email users when all evaluations for a document finish
- Checkbox on document create/import form to opt in
- Toggle on document management page for existing documents (supports re-runs and new evaluator additions)
- Document-specific email template with link to reader page

## Test plan
- [ ] **TestTab batch path** (#402): run a batch from TestTab with notification enabled, verify email on completion
- [ ] **Document creation**: create document with "Email me when evaluations complete" checked, verify email on completion
- [ ] **Import**: import document with notification checked, verify email
- [ ] **Toggle**: toggle notification on/off from document management page
- [ ] **Re-run**: re-run an eval with notification on, verify email arrives again
- [ ] **Add evaluator**: add a new evaluator to existing document, verify email on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in email notifications for evaluation completion (document-level and batch-level) with UI toggles on create/import, test runs, management, edit, and document pages.
  * Notification emails are sent when batches or documents complete; preference persisted per-document and per-batch.

* **Bug Fixes**
  * More accurate batch progress using terminal job counts.
  * Completion detection now uses explicit completion markers.
  * Admin cancellations now follow the unified cancellation flow for consistent outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->